### PR TITLE
Add automated daily scraping scheduler and AI briefing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ FundingCall_UK/
 2. 在浏览器中打开 `index.html`
 3. 使用搜索和过滤功能查找相关funding
 
+## 每日自动更新
+
+- 在服务器上执行一次更新并生成AI摘要: `python scrapers/update_all.py`
+- 持续运行的自动任务（默认每24小时运行一次）: `python scrapers/daily_scheduler.py`
+  - 如需测试单次运行: `python scrapers/daily_scheduler.py --run-once`
+  - 自定义运行间隔（例如每12小时）: `python scrapers/daily_scheduler.py --interval-hours 12`
+- 也可以将 `scrapers/daily_scheduler.py --run-once` 加入系统cron任务或GitHub Actions，实现每天定时抓取
+
+## AI 智能总结
+
+- 每次更新会在 `data/ai_summary.json` 生成自动化总结，前端首页“Daily AI Briefing”模块将实时展示
+- 总结内容包含：核心亮点、14天内截止的资助提醒、热门资助机构、面向的职业阶段及高额资助项目
+- 如需要自定义总结逻辑，可修改 `scrapers/summarizer.py`
+
 ## 部署到GitHub Pages
 
 1. 推送代码到GitHub仓库

--- a/css/style.css
+++ b/css/style.css
@@ -143,6 +143,95 @@ body {
     letter-spacing: 0.5px;
 }
 
+/* AI Briefing */
+.ai-briefing {
+    background: white;
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.08);
+    border: 1px solid rgba(102, 126, 234, 0.15);
+    margin-bottom: 3rem;
+}
+
+.ai-briefing-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.ai-briefing-header h2 {
+    font-size: 1.6rem;
+    color: #2c3e50;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ai-briefing-header i {
+    color: #667eea;
+}
+
+.ai-timestamp {
+    color: #6c757d;
+    font-size: 0.9rem;
+}
+
+.ai-overview {
+    font-size: 1rem;
+    margin-bottom: 1.5rem;
+    color: #495057;
+    line-height: 1.6;
+}
+
+.ai-briefing-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.ai-card {
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.08));
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(102, 126, 234, 0.25);
+    min-height: 180px;
+}
+
+.ai-card h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.05rem;
+    color: #2c3e50;
+    margin-bottom: 1rem;
+}
+
+.ai-card i {
+    color: #667eea;
+}
+
+.ai-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    color: #495057;
+}
+
+.ai-list li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.ai-list li span {
+    font-size: 0.85rem;
+    color: #6c757d;
+}
+
 /* Dashboard */
 .dashboard {
     margin: 3rem 0;

--- a/data/ai_summary.json
+++ b/data/ai_summary.json
@@ -1,0 +1,78 @@
+{
+  "generated_at": "2025-10-01T21:41:06.089900Z",
+  "overall_summary": "Daily crawl completed: 3057 opportunities consolidated with automatic categorisation across major UK funding bodies. Insights highlight where researchers should focus immediate attention and the most lucrative calls open right now.",
+  "highlights": [
+    "Captured 3057 funding opportunities covering 3 major categories.",
+    "Top thematic areas today: UKRI (2621), FOUNDATIONS (222), ACADEMIES (214).",
+    "Highest available award tops out at \u00a3110.00bn."
+  ],
+  "upcoming_deadlines": [],
+  "top_funding_bodies": [
+    {
+      "organization": "Arts and Humanities Research Council",
+      "opportunity_count": 1483
+    },
+    {
+      "organization": "Medical Research Council",
+      "opportunity_count": 242
+    },
+    {
+      "organization": "Engineering and Physical Sciences Research Council",
+      "opportunity_count": 216
+    },
+    {
+      "organization": "Biotechnology and Biological Sciences Research Council",
+      "opportunity_count": 148
+    },
+    {
+      "organization": "Economic and Social Research Council",
+      "opportunity_count": 146
+    }
+  ],
+  "career_stage_focus": [
+    {
+      "stage": "Early Career",
+      "opportunity_count": 1449
+    },
+    {
+      "stage": "All Stages",
+      "opportunity_count": 1161
+    },
+    {
+      "stage": "Mid Career",
+      "opportunity_count": 328
+    }
+  ],
+  "high_value_awards": [
+    {
+      "title": "Funding opportunity: Future Leaders Fellowships: round 10, business and non-academic",
+      "organization": "Innovate UK",
+      "amount": "\u00a3110.00bn",
+      "deadline": "17 Mar 2025"
+    },
+    {
+      "title": "Funding opportunity: MRC Centre of Research Excellence: round three: invited full application",
+      "organization": "Medical Research Council",
+      "amount": "\u00a350.00bn",
+      "deadline": "15 May 2025"
+    },
+    {
+      "title": "Funding opportunity: UKRI cross research council responsive mode pilot scheme: round two full stage",
+      "organization": "Arts and Humanities Research Council",
+      "amount": "\u00a332.50bn",
+      "deadline": "02 Sep 2024"
+    },
+    {
+      "title": "Funding opportunity: Investor partnerships: clean energy and climate technologies",
+      "organization": "Arts and Humanities Research Council",
+      "amount": "\u00a330.00bn",
+      "deadline": "09 May 2025"
+    },
+    {
+      "title": "Funding opportunity: Developmental pathway funding scheme: invited stage two",
+      "organization": "Arts and Humanities Research Council",
+      "amount": "\u00a330.00bn",
+      "deadline": "07 May 2025"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -68,6 +68,36 @@
                 </div>
             </div>
 
+            <section class="ai-briefing" id="aiSummarySection">
+                <div class="ai-briefing-header">
+                    <h2><i class="fas fa-robot"></i> Daily AI Briefing</h2>
+                    <span class="ai-timestamp" id="aiSummaryTimestamp">-</span>
+                </div>
+                <p class="ai-overview" id="aiSummaryOverview"></p>
+                <div class="ai-briefing-grid">
+                    <div class="ai-card">
+                        <h3><i class="fas fa-star"></i> Key Highlights</h3>
+                        <ul class="ai-list" id="aiHighlights"></ul>
+                    </div>
+                    <div class="ai-card">
+                        <h3><i class="fas fa-hourglass-half"></i> Deadlines (Next 14 Days)</h3>
+                        <ul class="ai-list" id="aiUpcoming"></ul>
+                    </div>
+                    <div class="ai-card">
+                        <h3><i class="fas fa-building"></i> Top Funding Bodies</h3>
+                        <ul class="ai-list" id="aiTopBodies"></ul>
+                    </div>
+                    <div class="ai-card">
+                        <h3><i class="fas fa-user-friends"></i> Career Stage Focus</h3>
+                        <ul class="ai-list" id="aiCareerFocus"></ul>
+                    </div>
+                    <div class="ai-card">
+                        <h3><i class="fas fa-pound-sign"></i> High-Value Awards</h3>
+                        <ul class="ai-list" id="aiHighValue"></ul>
+                    </div>
+                </div>
+            </section>
+
             <!-- Dashboard Section -->
             <div class="dashboard">
                 <h2 class="dashboard-title">

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,14 @@ const noResults = document.getElementById('noResults');
 const modal = document.getElementById('fundingModal');
 const closeModal = document.getElementById('closeModal');
 const modalContent = document.getElementById('modalContent');
+const aiSummaryOverview = document.getElementById('aiSummaryOverview');
+const aiSummaryTimestamp = document.getElementById('aiSummaryTimestamp');
+const aiHighlights = document.getElementById('aiHighlights');
+const aiUpcoming = document.getElementById('aiUpcoming');
+const aiTopBodies = document.getElementById('aiTopBodies');
+const aiCareerFocus = document.getElementById('aiCareerFocus');
+const aiHighValue = document.getElementById('aiHighValue');
+const aiSummarySection = document.getElementById('aiSummarySection');
 
 // Initialize the application
 document.addEventListener('DOMContentLoaded', function() {
@@ -39,13 +47,23 @@ function setupEventListeners() {
 // Load data from JSON files
 async function loadData() {
     try {
-        // Load main database
-        const response = await fetch('data/funding_database.json');
-        database = await response.json();
-        
+        const [databaseResponse, summaryResponse] = await Promise.all([
+            fetch('data/funding_database.json'),
+            fetch('data/ai_summary.json')
+        ]);
+
+        database = await databaseResponse.json();
+
+        if (summaryResponse.ok) {
+            const summaryData = await summaryResponse.json();
+            updateAISummary(summaryData);
+        } else {
+            showAISummaryFallback('AI summary is not available yet.');
+        }
+
         // Use the fundings from the database instead of sample data
         allFundings = database.fundings || [];
-        
+
         updateStats();
         filteredFundings = [...allFundings];
         sortAndDisplayFundings();
@@ -53,9 +71,69 @@ async function loadData() {
     } catch (error) {
         console.error('Error loading data:', error);
         showError('Failed to load funding data. Please try again later.');
+        showAISummaryFallback('Unable to load AI summary at this time.');
     } finally {
         loading.style.display = 'none';
     }
+}
+
+function updateAISummary(summary) {
+    if (!summary) {
+        showAISummaryFallback('AI summary is not available yet.');
+        return;
+    }
+
+    aiSummaryOverview.textContent = summary.overall_summary || 'Automated briefing is ready.';
+    aiSummaryTimestamp.textContent = summary.generated_at
+        ? `Generated at ${new Date(summary.generated_at).toLocaleString()}`
+        : '-';
+
+    renderList(aiHighlights, summary.highlights, item => `<li>${item}</li>`);
+    renderList(aiUpcoming, summary.upcoming_deadlines, item => `
+        <li>
+            <strong>${item.title}</strong>
+            <span>${item.organization} · Deadline: ${item.deadline} (${item.days_remaining} days left)</span>
+        </li>
+    `);
+    renderList(aiTopBodies, summary.top_funding_bodies, item => `
+        <li>
+            <strong>${item.organization}</strong>
+            <span>${item.opportunity_count} opportunities</span>
+        </li>
+    `);
+    renderList(aiCareerFocus, summary.career_stage_focus, item => `
+        <li>
+            <strong>${item.stage}</strong>
+            <span>${item.opportunity_count} opportunities</span>
+        </li>
+    `);
+    renderList(aiHighValue, summary.high_value_awards, item => `
+        <li>
+            <strong>${item.title}</strong>
+            <span>${item.organization} · ${item.amount} · Deadline: ${item.deadline}</span>
+        </li>
+    `);
+}
+
+function renderList(container, items, templateFn) {
+    if (!container) return;
+    if (!items || items.length === 0) {
+        container.innerHTML = '<li>No data available.</li>';
+        return;
+    }
+
+    container.innerHTML = items.map(templateFn).join('');
+}
+
+function showAISummaryFallback(message) {
+    if (!aiSummarySection) return;
+    aiSummaryOverview.textContent = message;
+    aiSummaryTimestamp.textContent = '-';
+    [aiHighlights, aiUpcoming, aiTopBodies, aiCareerFocus, aiHighValue].forEach(container => {
+        if (container) {
+            container.innerHTML = '<li>No data available.</li>';
+        }
+    });
 }
 
 

--- a/scrapers/daily_scheduler.py
+++ b/scrapers/daily_scheduler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Utility script to schedule the daily scraping routine."""
+
+import argparse
+import time
+from datetime import datetime, timezone
+
+from loguru import logger
+
+from update_all import FundingDataUpdater
+
+
+def run_update() -> bool:
+    updater = FundingDataUpdater()
+    success = updater.update_all()
+    if success:
+        logger.info("Daily update finished successfully")
+    else:
+        logger.error("Daily update encountered errors")
+    return success
+
+
+def sleep_until_next_run(interval_hours: float) -> None:
+    seconds = max(interval_hours * 3600, 60)
+    logger.info(f"Sleeping for {interval_hours} hours before the next run...")
+    time.sleep(seconds)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run funding scrapers on a schedule")
+    parser.add_argument(
+        "--interval-hours",
+        type=float,
+        default=24.0,
+        help="Interval in hours between runs when --run-once is not provided (default: 24)",
+    )
+    parser.add_argument(
+        "--run-once",
+        action="store_true",
+        help="Execute the update a single time and exit",
+    )
+
+    args = parser.parse_args()
+
+    if args.run_once:
+        run_update()
+        return
+
+    logger.info("Starting continuous update loop")
+    while True:
+        start = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        logger.info(f"Starting scheduled update at {start}")
+        run_update()
+        sleep_until_next_run(args.interval_hours)
+
+if __name__ == "__main__":
+    main()

--- a/scrapers/summarizer.py
+++ b/scrapers/summarizer.py
@@ -1,0 +1,177 @@
+"""Utility module for generating AI-style summaries of funding data."""
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List
+
+
+def _safe_get(dct: Dict, path: Iterable[str], default=""):
+    current = dct
+    for key in path:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+    return current
+
+
+def _format_currency(value: int) -> str:
+    if value is None or value <= 0:
+        return "Unknown"
+    if value >= 1_000_000_000:
+        return f"£{value/1_000_000_000:.2f}bn"
+    if value >= 1_000_000:
+        return f"£{value/1_000_000:.1f}m"
+    if value >= 1_000:
+        return f"£{value/1_000:.0f}k"
+    return f"£{value:,}"
+
+
+def _format_deadline(deadline: str) -> str:
+    try:
+        date_obj = datetime.fromisoformat(deadline)
+    except (TypeError, ValueError):
+        return "Date TBC"
+    return date_obj.strftime("%d %b %Y")
+
+
+def _extract_amount_range(funding: Dict) -> int:
+    amount = funding.get("funding_details", {}).get("amount", {})
+    return int(amount.get("max") or amount.get("min") or 0)
+
+
+def generate_ai_summary(fundings: List[Dict]) -> Dict:
+    """Create a structured natural-language summary for researchers."""
+    generated_at = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+    total = len(fundings)
+
+    if total == 0:
+        return {
+            "generated_at": generated_at,
+            "overall_summary": "No active funding opportunities were found in the latest crawl.",
+            "highlights": [
+                "The automated scrapers did not return any new opportunities today. Please check back later."
+            ],
+            "upcoming_deadlines": [],
+            "top_funding_bodies": [],
+            "career_stage_focus": [],
+        }
+
+    category_counter = Counter(f.get("category", "Uncategorised") for f in fundings)
+    top_categories = category_counter.most_common(3)
+
+    organisations = Counter(f.get("organization", "Unknown organisation") for f in fundings)
+    top_orgs = organisations.most_common(5)
+
+    career_stage_counter = Counter(
+        _safe_get(f, ("eligibility", "career_stage"), "All career stages") for f in fundings
+    )
+    top_career = career_stage_counter.most_common(3)
+
+    # Upcoming deadlines within 14 days
+    upcoming: List[Dict] = []
+    now = datetime.now(timezone.utc)
+    for funding in fundings:
+        deadline = _safe_get(funding, ("application", "deadline"))
+        try:
+            if not deadline:
+                continue
+            deadline_dt = datetime.fromisoformat(deadline)
+            if deadline_dt.tzinfo is None:
+                deadline_dt = deadline_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        delta = (deadline_dt - now).days
+        if 0 <= delta <= 14:
+            upcoming.append({
+                "title": funding.get("title", "Untitled opportunity"),
+                "organization": funding.get("organization", ""),
+                "deadline": deadline,
+                "days_remaining": delta,
+            })
+    upcoming.sort(key=lambda item: item["days_remaining"])
+    upcoming = upcoming[:5]
+
+    # High value opportunities
+    high_value_candidates = sorted(
+        [
+            {
+                "title": funding.get("title", "Untitled opportunity"),
+                "organization": funding.get("organization", ""),
+                "amount": _extract_amount_range(funding),
+                "deadline": _safe_get(funding, ("application", "deadline")),
+            }
+            for funding in fundings
+        ],
+        key=lambda item: item["amount"],
+        reverse=True,
+    )
+
+    high_value = []
+    seen_titles = set()
+    for item in high_value_candidates:
+        key = (item["title"], item["organization"], item["amount"])
+        if key in seen_titles:
+            continue
+        seen_titles.add(key)
+        high_value.append(item)
+        if len(high_value) == 5:
+            break
+
+    highlights = [
+        f"Captured {total} funding opportunities covering {len(category_counter)} major categories.",
+    ]
+    if top_categories:
+        highlights.append(
+            "Top thematic areas today: "
+            + ", ".join(f"{name.upper()} ({count})" for name, count in top_categories)
+            + "."
+        )
+    if upcoming:
+        highlights.append(
+            f"{len(upcoming)} opportunities are closing within the next two weeks; prioritise applications soon."
+        )
+    if high_value:
+        highlights.append(
+            f"Highest available award tops out at {_format_currency(high_value[0]['amount'])}."
+        )
+
+    overall_summary = (
+        "Daily crawl completed: "
+        f"{total} opportunities consolidated with automatic categorisation across major UK funding bodies. "
+        "Insights highlight where researchers should focus immediate attention and the most lucrative calls open right now."
+    )
+
+    return {
+        "generated_at": generated_at,
+        "overall_summary": overall_summary,
+        "highlights": highlights,
+        "upcoming_deadlines": [
+            {
+                "title": item["title"],
+                "organization": item["organization"],
+                "deadline": _format_deadline(item["deadline"]),
+                "days_remaining": item["days_remaining"],
+            }
+            for item in upcoming
+        ],
+        "top_funding_bodies": [
+            {"organization": name, "opportunity_count": count}
+            for name, count in top_orgs
+        ],
+        "career_stage_focus": [
+            {"stage": name, "opportunity_count": count}
+            for name, count in top_career
+        ],
+        "high_value_awards": [
+            {
+                "title": item["title"],
+                "organization": item["organization"],
+                "amount": _format_currency(item["amount"]),
+                "deadline": _format_deadline(item["deadline"]),
+            }
+            for item in high_value
+            if item["amount"] > 0
+        ],
+    }

--- a/scrapers/update_all.py
+++ b/scrapers/update_all.py
@@ -23,6 +23,7 @@ from ukri_scraper import UKRIScraper
 from academies_scraper import AcademiesScraper
 from foundations_scraper import FoundationsScraper
 from utils import setup_directories, update_database, save_json, load_json
+from summarizer import generate_ai_summary
 
 class FundingDataUpdater:
     """Main class to coordinate funding data updates."""
@@ -76,6 +77,7 @@ class FundingDataUpdater:
             if update_database(all_fundings, database_path):
                 logger.info(f"Successfully updated database with {len(all_fundings)} total opportunities")
                 self.generate_summary_report(all_fundings)
+                self.generate_ai_brief(all_fundings)
                 return True
             else:
                 logger.error("Failed to update main database")
@@ -186,6 +188,20 @@ class FundingDataUpdater:
         logger.info(f"  By career stage: {career_stage_counts}")
         logger.info(f"  Upcoming deadlines (30 days): {upcoming_deadlines}")
         logger.info(f"  Total funding range: £{total_min_funding:,} - £{total_max_funding:,}")
+
+    def generate_ai_brief(self, fundings: List[Dict]) -> None:
+        """Generate an AI-style natural language brief for the front-end."""
+        logger.info("Creating daily AI summary...")
+
+        try:
+            summary_payload = generate_ai_summary(fundings)
+        except Exception as exc:
+            logger.error(f"Failed to create AI summary: {exc}")
+            return
+
+        summary_path = self.dirs['data'] / 'ai_summary.json'
+        save_json(summary_payload, summary_path)
+        logger.info(f"AI summary saved to {summary_path}")
     
     def clean_old_data(self, days_old: int = 30) -> None:
         """Clean old individual funding files."""

--- a/test_summary.py
+++ b/test_summary.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from scrapers.summarizer import generate_ai_summary
+
+
+def test_generate_ai_summary_structure():
+    database_path = Path('data/funding_database.json')
+    data = json.loads(database_path.read_text())
+    fundings = data.get('fundings', [])
+
+    summary = generate_ai_summary(fundings)
+
+    assert 'overall_summary' in summary
+    assert isinstance(summary['highlights'], list)
+    assert isinstance(summary['top_funding_bodies'], list)
+    assert isinstance(summary['career_stage_focus'], list)
+    assert 'generated_at' in summary
+
+
+def test_generate_ai_summary_empty():
+    summary = generate_ai_summary([])
+    assert summary['highlights'][0].startswith('The automated scrapers')
+    assert summary['upcoming_deadlines'] == []


### PR DESCRIPTION
## Summary
- add AI summariser module that creates daily research funding briefings and integrate it into the updater
- expose a new Daily AI Briefing section on the homepage and style it for quick scanning
- provide a scheduler helper script plus documentation for running the scrapers automatically each day

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9ee3a418832eb292551459542609