### PR TITLE
Improve deadline handling in data sanitiser and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ FundingCall_UK/
 
 - 📊 **数据库系统**: JSON格式存储所有funding信息
 - 🕷️ **爬虫系统**: 自动获取最新funding信息
-- 🎨 **现代UI**: 响应式设计，便于快速浏览
-- 🔍 **搜索过滤**: 按类型、截止日期、金额等筛选
+- 🎨 **现代UI**: 响应式设计与数据仪表盘，便于快速浏览
+- 🔍 **搜索过滤**: 关键字检索、来源筛选、职业阶段筛选与排序
+- 🧭 **时间窗口管理**: 仅保留截止日期在当前前后三个月内且元数据完整的机会
 - 📱 **移动友好**: 适配各种设备
 
 ## 资助来源
@@ -59,8 +60,24 @@ FundingCall_UK/
 ## 使用方法
 
 1. 运行爬虫更新数据: `python scrapers/update_all.py`
-2. 在浏览器中打开 `index.html`
-3. 使用搜索和过滤功能查找相关funding
+2. 自动校验会剔除缺失字段、重复及不在 ±3 个月时间窗口内的机会
+3. 在浏览器中打开 `index.html`
+4. 使用侧边栏搜索和过滤功能查找相关funding
+
+## 每日自动更新
+
+- 在服务器上执行一次更新并生成AI摘要: `python scrapers/update_all.py`
+- 持续运行的自动任务（默认每24小时运行一次）: `python scrapers/daily_scheduler.py`
+  - 如需测试单次运行: `python scrapers/daily_scheduler.py --run-once`
+  - 自定义运行间隔（例如每12小时）: `python scrapers/daily_scheduler.py --interval-hours 12`
+- 也可以将 `scrapers/daily_scheduler.py --run-once` 加入系统cron任务或GitHub Actions，实现每天定时抓取
+
+## AI 智能总结
+
+- 每次更新会在 `data/ai_summary.json` 生成自动化总结，前端首页“Daily intelligence briefing” 模块将实时展示
+- 总结内容包含：核心亮点、14 天内截止提醒、热门资助机构、面向的职业阶段、高额资助项目，以及当前滚动时间窗口说明
+- 数据质量报告会在“Quality notes”中展示，便于追踪被剔除的条目类别
+- 如需要自定义总结逻辑，可修改 `scrapers/summarizer.py`
 
 ## 部署到GitHub Pages
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,671 +1,679 @@
-/* Reset and Base Styles */
+:root {
+    --bg: #0f172a;
+    --bg-muted: #1e293b;
+    --surface: #ffffff;
+    --surface-muted: rgba(255, 255, 255, 0.08);
+    --accent: #38bdf8;
+    --accent-strong: #0ea5e9;
+    --accent-soft: rgba(56, 189, 248, 0.12);
+    --text: #0f172a;
+    --text-muted: #475569;
+    --border: rgba(15, 23, 42, 0.08);
+    --shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+    --radius-lg: 24px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+    --transition: 180ms ease;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    color-scheme: light;
+}
+
 * {
-    margin: 0;
-    padding: 0;
     box-sizing: border-box;
 }
 
+html, body {
+    margin: 0;
+    background: #f1f5f9;
+    color: var(--text);
+}
+
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     line-height: 1.6;
-    color: #333;
-    background-color: #f8f9fa;
+    min-height: 100vh;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: var(--accent-strong);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
 }
 
 .container {
-    max-width: 1200px;
+    width: min(1200px, 90vw);
     margin: 0 auto;
-    padding: 0 20px;
 }
 
-/* Header */
-.header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    padding: 2rem 0;
-    text-align: center;
-}
-
-.header h1 {
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
-    font-weight: 700;
-}
-
-.header p {
-    font-size: 1.2rem;
-    opacity: 0.9;
-}
-
-.header i {
-    margin-right: 0.5rem;
-}
-
-/* Navigation */
-.nav {
-    background: white;
-    padding: 1.5rem 0;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-    position: sticky;
-    top: 0;
-    z-index: 100;
-}
-
-.nav-content {
+.page {
     display: flex;
-    gap: 2rem;
-    align-items: center;
-    flex-wrap: wrap;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
-.search-box {
+.hero {
+    background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.25), transparent 55%), var(--bg);
+    color: #e2e8f0;
+    padding: 72px 0 48px;
     position: relative;
-    flex: 1;
-    min-width: 300px;
+    overflow: hidden;
 }
 
-.search-box i {
+.hero::after {
+    content: "";
     position: absolute;
-    left: 1rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: #666;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(14, 165, 233, 0.18), transparent 50%);
+    opacity: 0.8;
+    pointer-events: none;
 }
 
-.search-box input {
-    width: 100%;
-    padding: 0.75rem 1rem 0.75rem 3rem;
-    border: 2px solid #e9ecef;
-    border-radius: 25px;
-    font-size: 1rem;
-    transition: border-color 0.3s ease;
+.hero__container {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 48px;
+    z-index: 1;
 }
 
-.search-box input:focus {
-    outline: none;
-    border-color: #667eea;
+.hero__intro h1 {
+    font-size: clamp(2.5rem, 4vw, 3.25rem);
+    margin: 16px 0 12px;
+    letter-spacing: -0.02em;
+}
+
+.hero__intro p {
+    color: rgba(226, 232, 240, 0.9);
+    margin-bottom: 28px;
+    font-size: 1.05rem;
+}
+
+.hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(56, 189, 248, 0.16);
+    color: #bae6fd;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+}
+
+.hero__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+}
+
+.hero__stat {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.hero__stat-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.hero__stat-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.hero__snapshot {
+    background: rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(14px);
+    padding: 32px;
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    align-self: flex-end;
+    min-height: 220px;
+    display: flex;
+    align-items: center;
+}
+
+.hero__snapshot-text {
+    font-size: 1.1rem;
+    color: #e0f2fe;
+    margin: 0;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 40px;
+    padding: 56px 0 72px;
+    flex: 1;
+}
+
+@media (max-width: 1024px) {
+    .layout {
+        grid-template-columns: 1fr;
+    }
+
+    .filters {
+        order: 2;
+    }
 }
 
 .filters {
+    position: sticky;
+    top: 32px;
+    align-self: start;
+}
+
+.filter-card {
+    background: #fff;
+    border-radius: var(--radius-lg);
+    padding: 32px;
+    box-shadow: var(--shadow);
+}
+
+.filter-card h2 {
+    margin-top: 0;
+    margin-bottom: 24px;
+    font-size: 1.25rem;
+}
+
+.filter-group {
     display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 24px;
 }
 
-.filters select {
-    padding: 0.75rem 1rem;
-    border: 2px solid #e9ecef;
-    border-radius: 8px;
+.filter-group--meta {
+    background: #f8fafc;
+    padding: 20px;
+    border-radius: var(--radius-md);
+    border: 1px dashed rgba(15, 23, 42, 0.12);
     font-size: 0.9rem;
-    background: white;
-    cursor: pointer;
-    transition: border-color 0.3s ease;
+    color: var(--text-muted);
 }
 
-.filters select:focus {
-    outline: none;
-    border-color: #667eea;
-}
-
-/* Stats Bar */
-.stats-bar {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    margin: 2rem 0;
-}
-
-.stat {
-    background: white;
-    padding: 1.5rem;
-    border-radius: 12px;
-    text-align: center;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    transition: transform 0.3s ease;
-}
-
-.stat:hover {
-    transform: translateY(-2px);
-}
-
-.stat-number {
-    display: block;
-    font-size: 2rem;
-    font-weight: 700;
-    color: #667eea;
-    margin-bottom: 0.5rem;
-}
-
-.stat-label {
-    color: #666;
-    font-size: 0.9rem;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
-
-/* Dashboard */
-.dashboard {
-    margin: 3rem 0;
-    background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-    border-radius: 16px;
-    padding: 2rem;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.1);
-}
-
-.dashboard-title {
-    text-align: center;
-    color: #2c3e50;
-    font-size: 1.8rem;
-    font-weight: 700;
-    margin-bottom: 2rem;
+.input-icon {
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
+    gap: 10px;
+    background: #f8fafc;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: var(--radius-md);
+    padding: 0 16px;
 }
 
-.dashboard-title i {
-    color: #667eea;
-}
-
-.dashboard-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1.5rem;
-}
-
-.dashboard-card {
-    background: white;
-    border-radius: 12px;
-    padding: 1.5rem;
-    box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-    transition: all 0.3s ease;
-    border: 1px solid rgba(102, 126, 234, 0.1);
-}
-
-.dashboard-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 30px rgba(0,0,0,0.15);
-    border-color: rgba(102, 126, 234, 0.3);
-}
-
-.dashboard-card-header {
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid #f8f9fa;
-}
-
-.dashboard-card-header h3 {
-    color: #2c3e50;
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.dashboard-card-header i {
-    color: #667eea;
+.input-icon input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 14px 0;
     font-size: 1rem;
 }
 
-.dashboard-card-content {
-    color: #555;
+.input-icon input:focus {
+    outline: none;
 }
 
-/* Dashboard Stats Styles */
-.category-stats, .career-stats, .organization-stats {
+.pill-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.pill {
+    background: #f1f5f9;
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-size: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.pill input {
+    accent-color: var(--accent-strong);
+}
+
+.pill:hover {
+    background: #e2e8f0;
+}
+
+select {
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    padding: 12px;
+    font-size: 1rem;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 999px;
+    padding: 10px 18px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.button--ghost {
+    background: transparent;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    color: var(--text);
+}
+
+.button--ghost:hover {
+    border-color: var(--accent);
+    color: var(--accent-strong);
+}
+
+.content {
     display: flex;
     flex-direction: column;
-    gap: 0.8rem;
+    gap: 40px;
+}
+
+.ai-briefing {
+    background: #ffffff;
+    border-radius: var(--radius-lg);
+    padding: 36px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.ai-briefing__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.ai-briefing__header h2 {
+    margin: 0;
+    font-size: 1.6rem;
+}
+
+.ai-briefing__meta {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.ai-briefing__overview {
+    margin: 0;
+    font-size: 1.05rem;
+    color: var(--text);
+}
+
+.ai-briefing__window {
+    margin: 6px 0 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.ai-briefing__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.ai-card {
+    background: linear-gradient(135deg, #f8fafc, #fff);
+    border-radius: var(--radius-md);
+    padding: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    min-height: 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.ai-card h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.ai-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.ai-list li strong {
+    color: var(--text);
+}
+
+.ai-briefing__notes {
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
+    padding-top: 16px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.ai-briefing__notes span {
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    border-radius: 999px;
+    padding: 6px 12px;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.section-header p {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+}
+
+.insights__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 20px;
+}
+
+.insight-card {
+    background: #fff;
+    border-radius: var(--radius-md);
+    padding: 24px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    min-height: 220px;
+}
+
+.insight-card h3 {
+    margin-top: 0;
+    font-size: 1.05rem;
+}
+
+.stat-block {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: var(--text-muted);
 }
 
 .stat-item {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.stat-item:last-child {
-    border-bottom: none;
-}
-
-.stat-label {
-    font-weight: 500;
-    color: #2c3e50;
-}
-
-.stat-value {
-    font-weight: 600;
-    color: #667eea;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .stat-bar {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.stat-label {
+    font-weight: 600;
+    color: var(--text);
 }
 
 .stat-progress {
-    flex: 1;
-    height: 8px;
-    background: #f0f0f0;
-    border-radius: 4px;
+    height: 6px;
+    background: #e2e8f0;
+    border-radius: 999px;
     overflow: hidden;
 }
 
 .stat-progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #667eea, #764ba2);
-    border-radius: 4px;
-    transition: width 0.3s ease;
+    background: linear-gradient(90deg, var(--accent), var(--accent-strong));
 }
 
-.funding-range {
-    text-align: center;
+.results {
+    background: #fff;
+    border-radius: var(--radius-lg);
+    padding: 36px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
 }
 
-.range-item {
-    margin: 1rem 0;
-    padding: 1rem;
-    background: #f8f9fa;
-    border-radius: 8px;
-    border-left: 4px solid #667eea;
+.results__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
 }
 
-.range-label {
-    font-size: 0.9rem;
-    color: #666;
-    margin-bottom: 0.5rem;
-}
-
-.range-value {
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: #2c3e50;
-}
-
-.deadline-stats {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
-.deadline-item {
-    text-align: center;
-    padding: 1rem;
-    background: #f8f9fa;
-    border-radius: 8px;
-}
-
-.deadline-number {
-    display: block;
+.results__header h2 {
+    margin: 0;
     font-size: 1.5rem;
-    font-weight: 700;
-    color: #667eea;
-    margin-bottom: 0.5rem;
 }
 
-.deadline-label {
-    font-size: 0.8rem;
-    color: #666;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
+.results__controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
-.competition-stats {
-    text-align: center;
-}
-
-.competition-item {
-    margin: 1rem 0;
-    padding: 1rem;
-    border-radius: 8px;
-}
-
-.competition-low {
-    background: linear-gradient(135deg, #d4edda, #c3e6cb);
-    color: #155724;
-}
-
-.competition-medium {
-    background: linear-gradient(135deg, #fff3cd, #ffeaa7);
-    color: #856404;
-}
-
-.competition-high {
-    background: linear-gradient(135deg, #f8d7da, #f5c6cb);
-    color: #721c24;
-}
-
-.competition-level {
-    font-weight: 600;
-    font-size: 1.1rem;
-    margin-bottom: 0.5rem;
-}
-
-.competition-desc {
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-
-/* Funding Grid */
-.funding-grid {
+.results__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 24px;
 }
 
 .funding-card {
-    background: white;
-    border-radius: 12px;
-    padding: 1.5rem;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    transition: all 0.3s ease;
-    cursor: pointer;
-    border-left: 4px solid #667eea;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: var(--radius-md);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    position: relative;
+    background: #ffffff;
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .funding-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+    transform: translateY(-6px);
+    box-shadow: 0 20px 30px rgba(15, 23, 42, 0.12);
 }
 
-.funding-card.urgent {
-    border-left-color: #e74c3c;
-}
-
-.funding-card.closing-soon {
-    border-left-color: #f39c12;
-}
-
-.card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 1rem;
-}
-
-.card-title {
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: #2c3e50;
-    margin-bottom: 0.5rem;
-    line-height: 1.3;
-}
-
-.card-organization {
-    color: #667eea;
-    font-weight: 500;
-    font-size: 0.9rem;
-}
-
-.card-amount {
-    background: #667eea;
-    color: white;
-    padding: 0.3rem 0.8rem;
-    border-radius: 20px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    white-space: nowrap;
-}
-
-.card-description {
-    color: #666;
-    margin-bottom: 1rem;
-    line-height: 1.5;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
-.card-details {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 1rem;
-}
-
-.detail-item {
-    display: flex;
+.funding-card__badge {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
+    gap: 8px;
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
 }
 
-.detail-item i {
-    color: #667eea;
-    width: 16px;
+.funding-card__title {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text);
 }
 
-.card-tags {
+.funding-card__meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
+    gap: 12px 18px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
 }
 
-.tag {
-    background: #f8f9fa;
-    color: #495057;
-    padding: 0.2rem 0.6rem;
-    border-radius: 12px;
-    font-size: 0.8rem;
-    border: 1px solid #e9ecef;
+.funding-card__description {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
 }
 
-.card-footer {
+.funding-card__footer {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-top: 1rem;
-    border-top: 1px solid #e9ecef;
-}
-
-.deadline {
-    font-weight: 600;
-    color: #e74c3c;
-}
-
-.deadline.safe {
-    color: #27ae60;
-}
-
-.deadline.warning {
-    color: #f39c12;
-}
-
-.view-details {
-    background: #667eea;
-    color: white;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    cursor: pointer;
     font-size: 0.9rem;
-    transition: background-color 0.3s ease;
 }
 
-.view-details:hover {
-    background: #5a6fd8;
+.funding-card__deadline {
+    font-weight: 600;
+    color: var(--text);
 }
 
-/* Loading and No Results */
-.loading, .no-results {
+.funding-card__button {
+    border: none;
+    background: transparent;
+    color: var(--accent-strong);
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.results__empty, .results__loading {
     text-align: center;
-    padding: 3rem;
-    color: #666;
+    color: var(--text-muted);
+    padding: 40px 20px;
+    border: 1px dashed rgba(148, 163, 184, 0.2);
+    border-radius: var(--radius-md);
 }
 
-.loading i {
+.results__empty i, .results__loading i {
     font-size: 2rem;
-    color: #667eea;
-    margin-bottom: 1rem;
+    margin-bottom: 12px;
+    color: var(--accent-strong);
 }
 
-.no-results i {
-    font-size: 3rem;
-    color: #ccc;
-    margin-bottom: 1rem;
+.footer {
+    background: var(--bg);
+    color: rgba(226, 232, 240, 0.85);
+    padding: 48px 0 32px;
+    margin-top: auto;
 }
 
-/* Modal */
+.footer__container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    margin-bottom: 32px;
+}
+
+.footer h3 {
+    margin-top: 0;
+    color: #fff;
+}
+
+.footer__bottom {
+    text-align: center;
+    margin: 0;
+    color: rgba(226, 232, 240, 0.6);
+    font-size: 0.85rem;
+}
+
 .modal {
-    display: none;
     position: fixed;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0,0,0,0.5);
-    animation: fadeIn 0.3s ease;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 32px;
+    z-index: 100;
 }
 
-.modal-content {
-    background-color: white;
-    margin: 5% auto;
-    padding: 2rem;
-    border-radius: 12px;
-    width: 90%;
-    max-width: 800px;
-    max-height: 80vh;
+.modal[hidden] {
+    display: none;
+}
+
+.modal__dialog {
+    background: #fff;
+    border-radius: var(--radius-lg);
+    max-width: 720px;
+    width: min(720px, 95vw);
+    max-height: 90vh;
     overflow-y: auto;
     position: relative;
-    animation: slideIn 0.3s ease;
+    padding: 36px;
 }
 
-.close {
+#modalContent {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    color: var(--text);
+}
+
+#modalContent p {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.modal__close {
     position: absolute;
-    right: 1rem;
-    top: 1rem;
-    font-size: 2rem;
-    font-weight: bold;
+    top: 18px;
+    right: 18px;
+    border: none;
+    background: rgba(15, 23, 42, 0.08);
+    color: var(--text);
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
     cursor: pointer;
-    color: #999;
-    transition: color 0.3s ease;
 }
 
-.close:hover {
-    color: #333;
+.modal__close:hover {
+    background: rgba(14, 165, 233, 0.15);
 }
 
-/* Footer */
-.footer {
-    background: #2c3e50;
-    color: white;
-    padding: 3rem 0 1rem;
-    margin-top: 4rem;
+.modal__content h3 {
+    margin-top: 0;
 }
 
-.footer-content {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-    margin-bottom: 2rem;
-}
-
-.footer-section h3 {
-    margin-bottom: 1rem;
-    color: #667eea;
-}
-
-.footer-section ul {
-    list-style: none;
-}
-
-.footer-section ul li {
-    margin-bottom: 0.5rem;
-}
-
-.footer-section a {
-    color: #667eea;
-    text-decoration: none;
-}
-
-.footer-section a:hover {
-    text-decoration: underline;
-}
-
-.footer-bottom {
-    text-align: center;
-    padding-top: 2rem;
-    border-top: 1px solid #34495e;
-    color: #bdc3c7;
-}
-
-/* Animations */
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-@keyframes slideIn {
-    from { transform: translateY(-50px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-    .header h1 {
-        font-size: 2rem;
+@media (max-width: 640px) {
+    .hero {
+        padding: 56px 0 36px;
     }
-    
-    .nav-content {
-        flex-direction: column;
-        gap: 1rem;
-    }
-    
-    .search-box {
-        min-width: 100%;
-    }
-    
-    .filters {
-        width: 100%;
-        justify-content: center;
-    }
-    
-    .funding-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .card-details {
-        grid-template-columns: 1fr;
-    }
-    
-    .modal-content {
-        margin: 10% auto;
-        width: 95%;
-        padding: 1rem;
-    }
-}
 
-@media (max-width: 480px) {
-    .container {
-        padding: 0 10px;
+    .hero__stats {
+        gap: 16px;
     }
-    
-    .header {
-        padding: 1.5rem 0;
+
+    .hero__stat-value {
+        font-size: 1.6rem;
     }
-    
-    .header h1 {
-        font-size: 1.8rem;
+
+    .filter-card {
+        padding: 24px;
     }
-    
-    .stats-bar {
-        grid-template-columns: repeat(2, 1fr);
-    }
-    
-    .card-footer {
-        flex-direction: column;
-        gap: 1rem;
-        align-items: flex-start;
+
+    .ai-briefing,
+    .results {
+        padding: 24px;
     }
 }

--- a/data/ai_summary.json
+++ b/data/ai_summary.json
@@ -1,0 +1,57 @@
+{
+  "generated_at": "2025-10-01T21:41:06.089900Z",
+  "overall_summary": "Daily crawl completed: 42 validated opportunities remain after quality checks, all with deadlines inside the rolling three-month window. Insights highlight where researchers should focus immediate attention and the most lucrative calls open right now.",
+  "highlights": [
+    "Curated 42 funding opportunities with deadlines between 01 Sep 2025 – 30 Nov 2025.",
+    "Top thematic areas today: UKRI (24), FOUNDATIONS (11), ACADEMIES (7).",
+    "Highest available award tops out at £4.5m."
+  ],
+  "upcoming_deadlines": [
+    {
+      "title": "Translational Medicine Catalyst",
+      "organization": "Medical Research Council",
+      "deadline": "04 Oct 2025",
+      "days_remaining": 3
+    },
+    {
+      "title": "Climate Action Innovation Fund",
+      "organization": "Wellcome Trust",
+      "deadline": "11 Oct 2025",
+      "days_remaining": 10
+    }
+  ],
+  "top_funding_bodies": [
+    { "organization": "Engineering and Physical Sciences Research Council", "opportunity_count": 9 },
+    { "organization": "Wellcome Trust", "opportunity_count": 6 },
+    { "organization": "Royal Society", "opportunity_count": 5 }
+  ],
+  "career_stage_focus": [
+    { "stage": "Early Career", "opportunity_count": 16 },
+    { "stage": "Mid Career", "opportunity_count": 12 },
+    { "stage": "Senior", "opportunity_count": 14 }
+  ],
+  "high_value_awards": [
+    {
+      "title": "Flagship Quantum Technologies Programme",
+      "organization": "Engineering and Physical Sciences Research Council",
+      "amount": "£4.5m",
+      "deadline": "23 Nov 2025"
+    },
+    {
+      "title": "Discovery Research Challenge",
+      "organization": "Wellcome Trust",
+      "amount": "£2.0m",
+      "deadline": "14 Nov 2025"
+    }
+  ],
+  "coverage_window": {
+    "start": "2025-09-01T00:00:00+00:00",
+    "end": "2025-11-30T00:00:00+00:00",
+    "label": "01 Sep 2025 – 30 Nov 2025"
+  },
+  "quality_notes": [
+    "Curated 42 of 57 scraped opportunities after validation checks.",
+    "3 entries skipped due to missing critical metadata.",
+    "8 entries skipped due to deadlines outside the 3-month window."
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -3,203 +3,201 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>UK Academic Funding Tracker</title>
+    <title>UK Research Funding Radar</title>
     <link rel="stylesheet" href="css/style.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
 </head>
 <body>
-    <header class="header">
-        <div class="container">
-            <div class="header-content">
-                <h1><i class="fas fa-university"></i> UK Academic Funding Tracker</h1>
-                <p>Discover and track funding opportunities for UK academic staff</p>
-            </div>
-        </div>
-    </header>
-
-    <nav class="nav">
-        <div class="container">
-            <div class="nav-content">
-                <div class="search-box">
-                    <i class="fas fa-search"></i>
-                    <input type="text" id="searchInput" placeholder="Search funding opportunities...">
-                </div>
-                <div class="filters">
-                    <select id="categoryFilter">
-                        <option value="">All Categories</option>
-                        <option value="ukri">UKRI</option>
-                        <option value="academies">National Academies</option>
-                        <option value="foundations">Foundations & Trusts</option>
-                    </select>
-                    <select id="careerStageFilter">
-                        <option value="">All Career Stages</option>
-                        <option value="Early Career">Early Career</option>
-                        <option value="Mid Career">Mid Career</option>
-                        <option value="Senior">Senior</option>
-                    </select>
-                    <select id="sortBy">
-                        <option value="deadline">Sort by Deadline</option>
-                        <option value="amount">Sort by Amount</option>
-                        <option value="title">Sort by Title</option>
-                    </select>
-                </div>
-            </div>
-        </div>
-    </nav>
-
-    <main class="main">
-        <div class="container">
-            <div class="stats-bar">
-                <div class="stat">
-                    <span class="stat-number" id="totalFundings">0</span>
-                    <span class="stat-label">Total Opportunities</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number" id="activeFundings">0</span>
-                    <span class="stat-label">Currently Open</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number" id="closingSoon">0</span>
-                    <span class="stat-label">Closing Soon</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number" id="lastUpdated">-</span>
-                    <span class="stat-label">Last Updated</span>
-                </div>
-            </div>
-
-            <!-- Dashboard Section -->
-            <div class="dashboard">
-                <h2 class="dashboard-title">
-                    <i class="fas fa-chart-pie"></i>
-                    Funding Overview Dashboard
-                </h2>
-                
-                <div class="dashboard-grid">
-                    <!-- Category Distribution -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-layer-group"></i> By Category</h3>
+    <div class="page">
+        <header class="hero">
+            <div class="hero__container container">
+                <div class="hero__intro">
+                    <span class="hero__badge"><i class="fas fa-rotate"></i> Auto-refreshed daily</span>
+                    <h1>UK Research Funding Radar</h1>
+                    <p>Track every major UK grant with a curated three-month window and AI briefing tailored for busy researchers.</p>
+                    <div class="hero__stats">
+                        <div class="hero__stat">
+                            <span class="hero__stat-label">Active opportunities</span>
+                            <span class="hero__stat-value" id="totalFundings">0</span>
                         </div>
-                        <div class="dashboard-card-content">
-                            <div class="category-stats" id="categoryStats">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
+                        <div class="hero__stat">
+                            <span class="hero__stat-label">Closing within 30 days</span>
+                            <span class="hero__stat-value" id="closingSoon">0</span>
                         </div>
-                    </div>
-
-                    <!-- Career Stage Distribution -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-user-graduate"></i> By Career Stage</h3>
-                        </div>
-                        <div class="dashboard-card-content">
-                            <div class="career-stats" id="careerStats">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Funding Range -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-pound-sign"></i> Funding Range</h3>
-                        </div>
-                        <div class="dashboard-card-content">
-                            <div class="funding-range" id="fundingRange">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Deadline Analysis -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-calendar-alt"></i> Deadline Analysis</h3>
-                        </div>
-                        <div class="dashboard-card-content">
-                            <div class="deadline-stats" id="deadlineStats">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Top Organizations -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-building"></i> Top Organizations</h3>
-                        </div>
-                        <div class="dashboard-card-content">
-                            <div class="organization-stats" id="organizationStats">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Success Rate Insights -->
-                    <div class="dashboard-card">
-                        <div class="dashboard-card-header">
-                            <h3><i class="fas fa-chart-line"></i> Competition Level</h3>
-                        </div>
-                        <div class="dashboard-card-content">
-                            <div class="competition-stats" id="competitionStats">
-                                <!-- Will be populated by JavaScript -->
-                            </div>
+                        <div class="hero__stat">
+                            <span class="hero__stat-label">Last refreshed</span>
+                            <span class="hero__stat-value" id="lastUpdated">-</span>
                         </div>
                     </div>
                 </div>
+                <div class="hero__snapshot" id="heroHighlight">
+                    <p class="hero__snapshot-text">Loading briefing…</p>
+                </div>
             </div>
+        </header>
 
-            <div class="funding-grid" id="fundingGrid">
-                <!-- Funding cards will be dynamically inserted here -->
-            </div>
+        <main class="layout container">
+            <aside class="filters" aria-label="Filter funding opportunities">
+                <div class="filter-card">
+                    <h2>Search &amp; filter</h2>
+                    <div class="filter-group">
+                        <label for="searchInput">Keyword search</label>
+                        <div class="input-icon">
+                            <i class="fas fa-search"></i>
+                            <input type="text" id="searchInput" placeholder="Search title, organisation, summary…" autocomplete="off">
+                        </div>
+                    </div>
 
-            <div class="loading" id="loading">
-                <i class="fas fa-spinner fa-spin"></i>
-                <p>Loading funding opportunities...</p>
-            </div>
+                    <div class="filter-group">
+                        <span class="filter-label">Funding sources</span>
+                        <div class="pill-group" id="sourceFilters">
+                            <label class="pill"><input type="checkbox" value="ukri" checked> UKRI</label>
+                            <label class="pill"><input type="checkbox" value="academies" checked> National Academies</label>
+                            <label class="pill"><input type="checkbox" value="foundations" checked> Foundations &amp; Trusts</label>
+                        </div>
+                    </div>
 
-            <div class="no-results" id="noResults" style="display: none;">
-                <i class="fas fa-search"></i>
-                <h3>No funding opportunities found</h3>
-                <p>Try adjusting your search criteria or filters</p>
-            </div>
-        </div>
-    </main>
+                    <div class="filter-group">
+                        <label for="careerStageFilter">Career stage focus</label>
+                        <select id="careerStageFilter">
+                            <option value="">All stages</option>
+                            <option value="Early Career">Early Career</option>
+                            <option value="Mid Career">Mid Career</option>
+                            <option value="Senior">Senior</option>
+                        </select>
+                    </div>
 
-    <footer class="footer">
-        <div class="container">
-            <div class="footer-content">
-                <div class="footer-section">
+                    <div class="filter-group filter-group--meta">
+                        <p>We surface calls with deadlines from the past and next three months so you can quickly act on timely opportunities.</p>
+                        <button id="resetFilters" class="button button--ghost" type="button"><i class="fas fa-arrow-rotate-left"></i> Reset filters</button>
+                    </div>
+                </div>
+            </aside>
+
+            <section class="content">
+                <section class="ai-briefing" id="aiSummarySection">
+                    <header class="ai-briefing__header">
+                        <div>
+                            <h2><i class="fas fa-robot"></i> Daily intelligence briefing</h2>
+                            <p class="ai-briefing__window" id="aiCoverageWindow">Window: —</p>
+                        </div>
+                        <div class="ai-briefing__meta">
+                            <span id="aiSummaryTimestamp">—</span>
+                        </div>
+                    </header>
+                    <p class="ai-briefing__overview" id="aiSummaryOverview">Our AI assistant is preparing your summary…</p>
+                    <div class="ai-briefing__grid">
+                        <article class="ai-card">
+                            <h3><i class="fas fa-star"></i> Highlights</h3>
+                            <ul class="ai-list" id="aiHighlights"></ul>
+                        </article>
+                        <article class="ai-card">
+                            <h3><i class="fas fa-hourglass-half"></i> Deadlines (14 days)</h3>
+                            <ul class="ai-list" id="aiUpcoming"></ul>
+                        </article>
+                        <article class="ai-card">
+                            <h3><i class="fas fa-building"></i> Top funders</h3>
+                            <ul class="ai-list" id="aiTopBodies"></ul>
+                        </article>
+                        <article class="ai-card">
+                            <h3><i class="fas fa-user-graduate"></i> Career stages</h3>
+                            <ul class="ai-list" id="aiCareerFocus"></ul>
+                        </article>
+                        <article class="ai-card">
+                            <h3><i class="fas fa-gem"></i> High-value awards</h3>
+                            <ul class="ai-list" id="aiHighValue"></ul>
+                        </article>
+                    </div>
+                    <div class="ai-briefing__notes" id="qualityNotes" aria-live="polite"></div>
+                </section>
+
+                <section class="insights">
+                    <header class="section-header">
+                        <h2><i class="fas fa-chart-line"></i> Funding landscape snapshot</h2>
+                        <p>Where attention is concentrated across disciplines, organisations, and deadlines.</p>
+                    </header>
+                    <div class="insights__grid">
+                        <article class="insight-card">
+                            <h3>Category mix</h3>
+                            <div id="categoryStats" class="stat-block"></div>
+                        </article>
+                        <article class="insight-card">
+                            <h3>Career stage balance</h3>
+                            <div id="careerStats" class="stat-block"></div>
+                        </article>
+                        <article class="insight-card">
+                            <h3>Funding scale</h3>
+                            <div id="fundingRange" class="stat-block"></div>
+                        </article>
+                        <article class="insight-card">
+                            <h3>Deadline cadence</h3>
+                            <div id="deadlineStats" class="stat-block"></div>
+                        </article>
+                        <article class="insight-card">
+                            <h3>Leading organisations</h3>
+                            <div id="organizationStats" class="stat-block"></div>
+                        </article>
+                        <article class="insight-card">
+                            <h3>Competition signals</h3>
+                            <div id="competitionStats" class="stat-block"></div>
+                        </article>
+                    </div>
+                </section>
+
+                <section class="results" aria-live="polite">
+                    <header class="results__header">
+                        <div>
+                            <h2>Opportunity explorer</h2>
+                            <p id="resultSummary">Showing 0 opportunities</p>
+                        </div>
+                        <div class="results__controls">
+                            <label for="sortSelect">Sort by</label>
+                            <select id="sortSelect">
+                                <option value="deadline">Soonest deadline</option>
+                                <option value="amount">Largest award</option>
+                                <option value="title">Title A–Z</option>
+                            </select>
+                        </div>
+                    </header>
+                    <div class="results__grid" id="fundingGrid"></div>
+                    <div class="results__empty" id="noResults" hidden>
+                        <i class="fas fa-binoculars"></i>
+                        <h3>No opportunities match your filters</h3>
+                        <p>Try adjusting the search keywords or enabling more sources.</p>
+                    </div>
+                    <div class="results__loading" id="loading">
+                        <i class="fas fa-spinner fa-spin"></i>
+                        <p>Loading latest funding calls…</p>
+                    </div>
+                </section>
+            </section>
+        </main>
+
+        <footer class="footer">
+            <div class="container footer__container">
+                <div>
                     <h3>About</h3>
-                    <p>This tool helps UK academic staff discover and track funding opportunities from major research councils, academies, and foundations.</p>
+                    <p>Funding Radar curates UK research grants from UKRI, national academies, and leading foundations with daily updates and quality checks.</p>
                 </div>
-                <div class="footer-section">
-                    <h3>Data Sources</h3>
-                    <ul>
-                        <li>UK Research and Innovation (UKRI)</li>
-                        <li>National Academies</li>
-                        <li>Charitable Foundations</li>
-                    </ul>
+                <div>
+                    <h3>Data discipline</h3>
+                    <p>Only opportunities with verified metadata and deadlines inside a ±3 month window are shown, ensuring accuracy and actionability.</p>
                 </div>
-                <div class="footer-section">
-                    <h3>Contact</h3>
-                    <p>For updates and suggestions, please visit our <a href="#">GitHub repository</a>.</p>
+                <div>
+                    <h3>Contribute</h3>
+                    <p>Have feedback or new sources? <a href="https://github.com/" target="_blank" rel="noopener">Open an issue on GitHub</a>.</p>
                 </div>
             </div>
-            <div class="footer-bottom">
-                <p>&copy; 2024 UK Academic Funding Tracker. Data updated regularly via automated scrapers.</p>
-            </div>
-        </div>
-    </footer>
+            <p class="footer__bottom">&copy; 2024 UK Research Funding Radar.</p>
+        </footer>
+    </div>
 
-    <!-- Funding Detail Modal -->
-    <div class="modal" id="fundingModal">
-        <div class="modal-content">
-            <span class="close" id="closeModal">&times;</span>
-            <div id="modalContent">
-                <!-- Modal content will be dynamically inserted here -->
-            </div>
+    <div class="modal" id="fundingModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" hidden>
+        <div class="modal__dialog">
+            <button class="modal__close" id="closeModal" aria-label="Close details">
+                <i class="fas fa-times"></i>
+            </button>
+            <div id="modalContent"></div>
         </div>
     </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,542 +1,660 @@
-// Global variables
-let allFundings = [];
-let filteredFundings = [];
-let database = {};
+const STATE = {
+    fundings: [],
+    filtered: [],
+    summary: null,
+};
 
-// DOM elements
-const searchInput = document.getElementById('searchInput');
-const categoryFilter = document.getElementById('categoryFilter');
-const careerStageFilter = document.getElementById('careerStageFilter');
-const sortBy = document.getElementById('sortBy');
-const fundingGrid = document.getElementById('fundingGrid');
-const loading = document.getElementById('loading');
-const noResults = document.getElementById('noResults');
-const modal = document.getElementById('fundingModal');
-const closeModal = document.getElementById('closeModal');
-const modalContent = document.getElementById('modalContent');
+const WINDOW_DAYS = 90;
 
-// Initialize the application
-document.addEventListener('DOMContentLoaded', function() {
+const elements = {
+    searchInput: document.getElementById('searchInput'),
+    sourceFilters: document.querySelectorAll('#sourceFilters input[type="checkbox"]'),
+    careerStageFilter: document.getElementById('careerStageFilter'),
+    sortSelect: document.getElementById('sortSelect'),
+    fundingGrid: document.getElementById('fundingGrid'),
+    loading: document.getElementById('loading'),
+    noResults: document.getElementById('noResults'),
+    totalFundings: document.getElementById('totalFundings'),
+    closingSoon: document.getElementById('closingSoon'),
+    lastUpdated: document.getElementById('lastUpdated'),
+    resultSummary: document.getElementById('resultSummary'),
+    heroHighlight: document.getElementById('heroHighlight'),
+    aiSummarySection: document.getElementById('aiSummarySection'),
+    aiSummaryOverview: document.getElementById('aiSummaryOverview'),
+    aiSummaryTimestamp: document.getElementById('aiSummaryTimestamp'),
+    aiHighlights: document.getElementById('aiHighlights'),
+    aiUpcoming: document.getElementById('aiUpcoming'),
+    aiTopBodies: document.getElementById('aiTopBodies'),
+    aiCareerFocus: document.getElementById('aiCareerFocus'),
+    aiHighValue: document.getElementById('aiHighValue'),
+    aiCoverageWindow: document.getElementById('aiCoverageWindow'),
+    qualityNotes: document.getElementById('qualityNotes'),
+    resetFilters: document.getElementById('resetFilters'),
+    modal: document.getElementById('fundingModal'),
+    closeModal: document.getElementById('closeModal'),
+    modalContent: document.getElementById('modalContent'),
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    bindEvents();
     loadData();
-    setupEventListeners();
 });
 
-// Setup event listeners
-function setupEventListeners() {
-    searchInput.addEventListener('input', debounce(filterFundings, 300));
-    categoryFilter.addEventListener('change', filterFundings);
-    careerStageFilter.addEventListener('change', filterFundings);
-    sortBy.addEventListener('change', sortAndDisplayFundings);
-    
-    closeModal.addEventListener('click', closeModalHandler);
-    window.addEventListener('click', function(event) {
-        if (event.target === modal) {
-            closeModalHandler();
+function bindEvents() {
+    const debouncedFilter = debounce(applyFilters, 200);
+    elements.searchInput.addEventListener('input', debouncedFilter);
+    elements.careerStageFilter.addEventListener('change', applyFilters);
+    elements.sortSelect.addEventListener('change', () => {
+        sortFundings();
+        renderFundings();
+    });
+    elements.sourceFilters.forEach((checkbox) => {
+        checkbox.addEventListener('change', applyFilters);
+    });
+    if (elements.resetFilters) {
+        elements.resetFilters.addEventListener('click', resetFilters);
+    }
+    if (elements.closeModal) {
+        elements.closeModal.addEventListener('click', closeModal);
+    }
+    window.addEventListener('click', (event) => {
+        if (event.target === elements.modal) {
+            closeModal();
         }
     });
 }
 
-// Load data from JSON files
 async function loadData() {
     try {
-        // Load main database
-        const response = await fetch('data/funding_database.json');
-        database = await response.json();
-        
-        // Use the fundings from the database instead of sample data
-        allFundings = database.fundings || [];
-        
-        updateStats();
-        filteredFundings = [...allFundings];
-        sortAndDisplayFundings();
-        
-    } catch (error) {
-        console.error('Error loading data:', error);
-        showError('Failed to load funding data. Please try again later.');
-    } finally {
-        loading.style.display = 'none';
-    }
-}
+        const [databaseResponse, summaryResponse] = await Promise.all([
+            fetch('data/funding_database.json'),
+            fetch('data/ai_summary.json'),
+        ]);
 
-
-
-// Update statistics
-function updateStats() {
-    const totalFundings = allFundings.length;
-    const activeFundings = allFundings.filter(f => f.status === 'active').length;
-    const closingSoon = allFundings.filter(f => {
-        const deadline = new Date(f.application.deadline);
-        const now = new Date();
-        const diffTime = deadline - now;
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        return diffDays <= 30 && diffDays > 0;
-    }).length;
-    
-    document.getElementById('totalFundings').textContent = totalFundings;
-    document.getElementById('activeFundings').textContent = activeFundings;
-    document.getElementById('closingSoon').textContent = closingSoon;
-    document.getElementById('lastUpdated').textContent = new Date().toLocaleDateString();
-    
-    // Update dashboard
-    updateDashboard();
-}
-
-// Update dashboard with comprehensive statistics
-function updateDashboard() {
-    updateCategoryStats();
-    updateCareerStats();
-    updateFundingRange();
-    updateDeadlineStats();
-    updateOrganizationStats();
-    updateCompetitionStats();
-}
-
-// Update category distribution
-function updateCategoryStats() {
-    const categoryCount = {};
-    allFundings.forEach(funding => {
-        const category = funding.category || 'Other';
-        categoryCount[category] = (categoryCount[category] || 0) + 1;
-    });
-    
-    const total = allFundings.length;
-    const categoryStatsEl = document.getElementById('categoryStats');
-    
-    categoryStatsEl.innerHTML = Object.entries(categoryCount)
-        .sort((a, b) => b[1] - a[1])
-        .map(([category, count]) => {
-            const percentage = ((count / total) * 100).toFixed(1);
-            return `
-                <div class="stat-item">
-                    <div class="stat-bar">
-                        <span class="stat-label">${category}</span>
-                        <div class="stat-progress">
-                            <div class="stat-progress-fill" style="width: ${percentage}%"></div>
-                        </div>
-                        <span class="stat-value">${count} (${percentage}%)</span>
-                    </div>
-                </div>
-            `;
-        }).join('');
-}
-
-// Update career stage distribution
-function updateCareerStats() {
-    const careerCount = {};
-    allFundings.forEach(funding => {
-        const stage = funding.eligibility?.career_stage || 'All Stages';
-        careerCount[stage] = (careerCount[stage] || 0) + 1;
-    });
-    
-    const total = allFundings.length;
-    const careerStatsEl = document.getElementById('careerStats');
-    
-    careerStatsEl.innerHTML = Object.entries(careerCount)
-        .sort((a, b) => b[1] - a[1])
-        .map(([stage, count]) => {
-            const percentage = ((count / total) * 100).toFixed(1);
-            return `
-                <div class="stat-item">
-                    <div class="stat-bar">
-                        <span class="stat-label">${stage}</span>
-                        <div class="stat-progress">
-                            <div class="stat-progress-fill" style="width: ${percentage}%"></div>
-                        </div>
-                        <span class="stat-value">${count} (${percentage}%)</span>
-                    </div>
-                </div>
-            `;
-        }).join('');
-}
-
-// Update funding range statistics
-function updateFundingRange() {
-    const amounts = allFundings
-        .map(funding => {
-            const amount = funding.funding_details?.amount;
-            if (!amount) return null;
-            return {
-                min: amount.min || amount.max || 0,
-                max: amount.max || amount.min || 0
-            };
-        })
-        .filter(amount => amount && amount.min > 0);
-    
-    if (amounts.length === 0) {
-        document.getElementById('fundingRange').innerHTML = '<p>No funding amount data available</p>';
-        return;
-    }
-    
-    const minAmount = Math.min(...amounts.map(a => a.min));
-    const maxAmount = Math.max(...amounts.map(a => a.max));
-    const avgMin = amounts.reduce((sum, a) => sum + a.min, 0) / amounts.length;
-    const avgMax = amounts.reduce((sum, a) => sum + a.max, 0) / amounts.length;
-    
-    document.getElementById('fundingRange').innerHTML = `
-        <div class="range-item">
-            <div class="range-label">Minimum Available</div>
-            <div class="range-value">£${formatNumber(minAmount)}</div>
-        </div>
-        <div class="range-item">
-            <div class="range-label">Maximum Available</div>
-            <div class="range-value">£${formatNumber(maxAmount)}</div>
-        </div>
-        <div class="range-item">
-            <div class="range-label">Average Range</div>
-            <div class="range-value">£${formatNumber(avgMin)} - £${formatNumber(avgMax)}</div>
-        </div>
-    `;
-}
-
-// Update deadline analysis
-function updateDeadlineStats() {
-    const now = new Date();
-    let openNow = 0;
-    let closingSoon = 0;
-    let closedCount = 0;
-    let noDeadline = 0;
-    
-    allFundings.forEach(funding => {
-        if (!funding.application?.deadline) {
-            noDeadline++;
-            return;
+        if (!databaseResponse.ok) {
+            throw new Error('Unable to load funding database');
         }
-        
-        const deadline = new Date(funding.application.deadline);
-        const diffTime = deadline - now;
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        
-        if (diffDays < 0) {
-            closedCount++;
-        } else if (diffDays <= 30) {
-            closingSoon++;
+
+        const database = await databaseResponse.json();
+        const fundings = enforceWindow(database.fundings || []);
+        STATE.fundings = fundings;
+        STATE.filtered = [...fundings];
+
+        updateHeadlineMetrics(fundings, database.last_updated);
+        updateInsights(fundings);
+        sortFundings();
+        renderFundings();
+
+        if (summaryResponse.ok) {
+            const summary = await summaryResponse.json();
+            STATE.summary = summary;
+            updateAISummary(summary);
         } else {
-            openNow++;
+            showAISummaryFallback('AI summary is not available yet.');
         }
-    });
-    
-    document.getElementById('deadlineStats').innerHTML = `
-        <div class="deadline-item">
-            <span class="deadline-number">${openNow}</span>
-            <span class="deadline-label">Open Now</span>
-        </div>
-        <div class="deadline-item">
-            <span class="deadline-number">${closingSoon}</span>
-            <span class="deadline-label">Closing Soon</span>
-        </div>
-        <div class="deadline-item">
-            <span class="deadline-number">${closedCount}</span>
-            <span class="deadline-label">Closed</span>
-        </div>
-        <div class="deadline-item">
-            <span class="deadline-number">${noDeadline}</span>
-            <span class="deadline-label">No Deadline</span>
-        </div>
-    `;
-}
-
-// Update top organizations
-function updateOrganizationStats() {
-    const orgCount = {};
-    allFundings.forEach(funding => {
-        const org = funding.organization || 'Unknown';
-        orgCount[org] = (orgCount[org] || 0) + 1;
-    });
-    
-    const topOrgs = Object.entries(orgCount)
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 5);
-    
-    document.getElementById('organizationStats').innerHTML = topOrgs
-        .map(([org, count]) => `
-            <div class="stat-item">
-                <span class="stat-label">${org}</span>
-                <span class="stat-value">${count}</span>
-            </div>
-        `).join('');
-}
-
-// Update competition level analysis
-function updateCompetitionStats() {
-    const amounts = allFundings
-        .map(funding => funding.funding_details?.amount?.max || funding.funding_details?.amount?.min || 0)
-        .filter(amount => amount > 0);
-    
-    const avgAmount = amounts.length > 0 ? amounts.reduce((sum, a) => sum + a, 0) / amounts.length : 0;
-    const highValueCount = amounts.filter(a => a > avgAmount * 2).length;
-    const mediumValueCount = amounts.filter(a => a > avgAmount && a <= avgAmount * 2).length;
-    const lowValueCount = amounts.filter(a => a <= avgAmount).length;
-    
-    let competitionLevel = 'Low';
-    let competitionClass = 'competition-low';
-    let description = 'Generally accessible opportunities';
-    
-    if (highValueCount > amounts.length * 0.3) {
-        competitionLevel = 'High';
-        competitionClass = 'competition-high';
-        description = 'Many high-value, competitive opportunities';
-    } else if (mediumValueCount > amounts.length * 0.4) {
-        competitionLevel = 'Medium';
-        competitionClass = 'competition-medium';
-        description = 'Mix of competitive and accessible opportunities';
+    } catch (error) {
+        console.error(error);
+        showErrorState('We could not load the latest funding data. Please try again later.');
+        showAISummaryFallback('Unable to fetch AI summary at this time.');
+    } finally {
+        if (elements.loading) {
+            elements.loading.hidden = true;
+        }
     }
-    
-    document.getElementById('competitionStats').innerHTML = `
-        <div class="competition-item ${competitionClass}">
-            <div class="competition-level">${competitionLevel} Competition</div>
-            <div class="competition-desc">${description}</div>
-        </div>
-        <div style="margin-top: 1rem; font-size: 0.9rem; color: #666;">
-            High Value: ${highValueCount} | Medium: ${mediumValueCount} | Accessible: ${lowValueCount}
-        </div>
-    `;
 }
 
-// Filter fundings based on search and filters
-function filterFundings() {
-    const searchTerm = searchInput.value.toLowerCase();
-    const categoryValue = categoryFilter.value;
-    const careerStageValue = careerStageFilter.value;
-    
-    filteredFundings = allFundings.filter(funding => {
-        const matchesSearch = !searchTerm || 
-            funding.title.toLowerCase().includes(searchTerm) ||
-            funding.organization.toLowerCase().includes(searchTerm) ||
-            funding.description.toLowerCase().includes(searchTerm) ||
-            funding.tags.some(tag => tag.toLowerCase().includes(searchTerm));
-            
-        const matchesCategory = !categoryValue || funding.category === categoryValue;
-        const matchesCareerStage = !careerStageValue || funding.eligibility.career_stage === careerStageValue;
-        
-        return matchesSearch && matchesCategory && matchesCareerStage;
-    });
-    
-    sortAndDisplayFundings();
+function enforceWindow(fundings) {
+    const now = new Date();
+    const windowStart = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const windowEnd = new Date(now.getTime() + WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+    return fundings
+        .map((funding) => enrichFunding(funding, windowStart, windowEnd))
+        .filter((funding) => {
+            const deadline = getActiveDeadlineDate(funding);
+            if (!deadline) {
+                return false;
+            }
+            return deadline >= windowStart && deadline <= windowEnd;
+        });
 }
 
-// Sort and display fundings
-function sortAndDisplayFundings() {
-    const sortValue = sortBy.value;
-    
-    filteredFundings.sort((a, b) => {
-        switch (sortValue) {
-            case 'deadline':
-                return new Date(a.application.deadline) - new Date(b.application.deadline);
-            case 'amount':
-                return b.funding_details.amount.max - a.funding_details.amount.max;
-            case 'title':
-                return a.title.localeCompare(b.title);
-            default:
-                return 0;
-        }
-    });
-    
-    displayFundings();
-}
-
-// Display fundings in the grid
-function displayFundings() {
-    if (filteredFundings.length === 0) {
-        fundingGrid.style.display = 'none';
-        noResults.style.display = 'block';
+function updateHeadlineMetrics(fundings, lastUpdated) {
+    if (!elements.totalFundings || !elements.closingSoon || !elements.lastUpdated) {
         return;
     }
-    
-    fundingGrid.style.display = 'grid';
-    noResults.style.display = 'none';
-    
-    fundingGrid.innerHTML = filteredFundings.map(funding => createFundingCard(funding)).join('');
-    
-    // Add click listeners to cards
-    document.querySelectorAll('.funding-card').forEach(card => {
-        card.addEventListener('click', function() {
-            const fundingId = this.dataset.fundingId;
-            const funding = allFundings.find(f => f.id === fundingId);
-            showFundingDetails(funding);
-        });
+
+    elements.totalFundings.textContent = fundings.length.toString();
+
+    const closingSoon = fundings.filter((funding) => {
+        const deadline = getActiveDeadlineDate(funding);
+        if (!deadline) return false;
+        const diff = deadline.getTime() - Date.now();
+        const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+        return days > 0 && days <= 30;
+    }).length;
+    elements.closingSoon.textContent = closingSoon.toString();
+
+    if (lastUpdated) {
+        elements.lastUpdated.textContent = new Date(lastUpdated).toLocaleString();
+    } else {
+        elements.lastUpdated.textContent = new Date().toLocaleString();
+    }
+}
+
+function updateInsights(fundings) {
+    updateCategoryStats(fundings);
+    updateCareerStats(fundings);
+    updateFundingRange(fundings);
+    updateDeadlineStats(fundings);
+    updateOrganizationStats(fundings);
+    updateCompetitionStats(fundings);
+}
+
+function applyFilters() {
+    const query = elements.searchInput.value.trim().toLowerCase();
+    const selectedStages = elements.careerStageFilter.value;
+    const activeSources = Array.from(elements.sourceFilters)
+        .filter((checkbox) => checkbox.checked)
+        .map((checkbox) => checkbox.value);
+
+    let filtered = STATE.fundings.filter((funding) => {
+        const matchesSource = activeSources.includes((funding.category || '').toLowerCase());
+        if (!matchesSource) return false;
+
+        const matchesStage = !selectedStages || funding?.eligibility?.career_stage === selectedStages;
+        if (!matchesStage) return false;
+
+        if (!query) return true;
+        const haystack = [
+            funding.title,
+            funding.organization,
+            funding.description,
+            funding?.eligibility?.career_stage,
+        ]
+            .join(' ')
+            .toLowerCase();
+        return haystack.includes(query);
+    });
+
+    STATE.filtered = filtered;
+    sortFundings();
+    renderFundings();
+}
+
+function sortFundings() {
+    const mode = elements.sortSelect.value;
+    STATE.filtered.sort((a, b) => {
+        if (mode === 'title') {
+            return a.title.localeCompare(b.title);
+        }
+
+        if (mode === 'amount') {
+            const amountA = getAmountValue(a);
+            const amountB = getAmountValue(b);
+            return amountB - amountA;
+        }
+
+        const deadlineA = getActiveDeadlineDate(a) || new Date(8640000000000000);
+        const deadlineB = getActiveDeadlineDate(b) || new Date(8640000000000000);
+        return deadlineA - deadlineB;
     });
 }
 
-// Create funding card HTML
-function createFundingCard(funding) {
-    const deadline = new Date(funding.application.deadline);
-    const now = new Date();
-    const diffTime = deadline - now;
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    
-    let deadlineClass = 'safe';
-    let cardClass = '';
-    if (diffDays <= 7) {
-        deadlineClass = 'urgent';
-        cardClass = 'urgent';
-    } else if (diffDays <= 30) {
-        deadlineClass = 'warning';
-        cardClass = 'closing-soon';
+function renderFundings() {
+    if (!elements.fundingGrid) return;
+
+    const hasResults = STATE.filtered.length > 0;
+    elements.noResults.hidden = hasResults;
+    elements.fundingGrid.innerHTML = '';
+
+    if (!hasResults) {
+        elements.resultSummary.textContent = 'Showing 0 opportunities';
+        return;
     }
-    
-    const amount = funding.funding_details.amount;
-    const amountText = amount.min === amount.max ? 
-        `£${formatNumber(amount.max)}` : 
-        `£${formatNumber(amount.min)} - £${formatNumber(amount.max)}`;
-    
+
+    elements.resultSummary.textContent = `Showing ${STATE.filtered.length} opportunities`;
+
+    const fragment = document.createDocumentFragment();
+
+    STATE.filtered.forEach((funding) => {
+        const card = document.createElement('article');
+        card.className = 'funding-card';
+        card.innerHTML = createFundingCardMarkup(funding);
+        const button = card.querySelector('button[data-id]');
+        if (button) {
+            button.addEventListener('click', () => openModal(funding));
+        }
+        fragment.appendChild(card);
+    });
+
+    elements.fundingGrid.appendChild(fragment);
+}
+
+function createFundingCardMarkup(funding) {
+    const { label: deadlineLabel, formatted } = getDeadlineDisplay(funding);
+    const deadline = formatted || 'Date TBC';
+    const amount = formatCurrencyDisplay(getAmountValue(funding));
+    const category = (funding.category || 'Other').toUpperCase();
+    const organization = funding.organization || 'Unknown organisation';
+    const description = (funding.description || '').slice(0, 180);
+
     return `
-        <div class="funding-card ${cardClass}" data-funding-id="${funding.id}">
-            <div class="card-header">
-                <div>
-                    <h3 class="card-title">${funding.title}</h3>
-                    <div class="card-organization">${funding.organization}</div>
-                </div>
-                <div class="card-amount">${amountText}</div>
-            </div>
-            
-            <p class="card-description">${funding.description}</p>
-            
-            <div class="card-details">
-                <div class="detail-item">
-                    <i class="fas fa-user-graduate"></i>
-                    <span>${funding.eligibility.career_stage}</span>
-                </div>
-                <div class="detail-item">
-                    <i class="fas fa-clock"></i>
-                    <span>${funding.funding_details.amount.duration_years} years</span>
-                </div>
-                <div class="detail-item">
-                    <i class="fas fa-chart-line"></i>
-                    <span>${funding.key_info.success_rate || 'N/A'}</span>
-                </div>
-                <div class="detail-item">
-                    <i class="fas fa-calendar"></i>
-                    <span>${funding.application.frequency}</span>
-                </div>
-            </div>
-            
-            <div class="card-tags">
-                ${funding.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
-            </div>
-            
-            <div class="card-footer">
-                <div class="deadline ${deadlineClass}">
-                    <i class="fas fa-calendar-alt"></i>
-                    Deadline: ${formatDate(deadline)}
-                    ${diffDays > 0 ? `(${diffDays} days)` : '(Closed)'}
-                </div>
-                <button class="view-details">View Details</button>
-            </div>
+        <span class="funding-card__badge"><i class="fas fa-layer-group"></i> ${category}</span>
+        <h3 class="funding-card__title">${funding.title}</h3>
+        <div class="funding-card__meta">
+            <span><i class="fas fa-building"></i> ${organization}</span>
+            <span><i class="fas fa-pound-sign"></i> ${amount}</span>
+        </div>
+        <p class="funding-card__description">${description}${description.length === 180 ? '…' : ''}</p>
+        <div class="funding-card__footer">
+            <span class="funding-card__deadline"><i class="fas fa-calendar"></i> ${deadlineLabel}: ${deadline}</span>
+            <button class="funding-card__button" data-id="${funding.id}"><span>View details</span> <i class="fas fa-arrow-right"></i></button>
         </div>
     `;
 }
 
-// Show funding details in modal
-function showFundingDetails(funding) {
-    const amount = funding.funding_details.amount;
-    const amountText = amount.min === amount.max ? 
-        `£${formatNumber(amount.max)}` : 
-        `£${formatNumber(amount.min)} - £${formatNumber(amount.max)}`;
-    
-    modalContent.innerHTML = `
-        <h2>${funding.title}</h2>
-        <h3 style="color: #667eea; margin-bottom: 2rem;">${funding.organization}</h3>
-        
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
-            <div>
-                <h4><i class="fas fa-info-circle"></i> Overview</h4>
-                <p style="margin-bottom: 1rem;">${funding.description}</p>
-                
-                <h4><i class="fas fa-pound-sign"></i> Funding Details</h4>
-                <ul style="margin-bottom: 1rem;">
-                    <li><strong>Amount:</strong> ${amountText}</li>
-                    <li><strong>Duration:</strong> ${funding.funding_details.amount.duration_years} years</li>
-                    <li><strong>Covers:</strong> ${funding.funding_details.covers.join(', ')}</li>
-                </ul>
-                
-                <h4><i class="fas fa-calendar"></i> Application</h4>
-                <ul style="margin-bottom: 1rem;">
-                    <li><strong>Deadline:</strong> ${formatDate(new Date(funding.application.deadline))}</li>
-                    <li><strong>Next Deadline:</strong> ${formatDate(new Date(funding.application.next_deadline))}</li>
-                    <li><strong>Frequency:</strong> ${funding.application.frequency}</li>
-                </ul>
-            </div>
-            
-            <div>
-                <h4><i class="fas fa-user-check"></i> Eligibility</h4>
-                <ul style="margin-bottom: 1rem;">
-                    <li><strong>Career Stage:</strong> ${funding.eligibility.career_stage}</li>
-                    <li><strong>Disciplines:</strong> ${funding.eligibility.disciplines.join(', ')}</li>
-                </ul>
-                <div style="margin-bottom: 1rem;">
-                    <strong>Requirements:</strong>
-                    <ul style="margin-left: 1rem;">
-                        ${funding.eligibility.requirements.map(req => `<li>${req}</li>`).join('')}
-                    </ul>
-                </div>
-                
-                <h4><i class="fas fa-chart-bar"></i> Key Information</h4>
-                <ul style="margin-bottom: 1rem;">
-                    <li><strong>Priority Level:</strong> ${funding.key_info.priority_level}</li>
-                    <li><strong>Competition Level:</strong> ${funding.key_info.competition_level}</li>
-                    <li><strong>Success Rate:</strong> ${funding.key_info.success_rate || 'N/A'}</li>
-                </ul>
-                
-                <div style="margin-top: 2rem;">
-                    <a href="${funding.scraped_from || funding.application.application_url}" target="_blank" 
-                       style="background: #667eea; color: white; padding: 0.75rem 1.5rem; 
-                              border-radius: 6px; text-decoration: none; display: inline-block;">
-                        <i class="fas fa-external-link-alt"></i> Apply Now
-                    </a>
-                </div>
-            </div>
-        </div>
-        
-        <div style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #eee;">
-            <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-                ${funding.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
-            </div>
+function openModal(funding) {
+    if (!elements.modal || !elements.modalContent) return;
+
+    const { label: deadlineLabel, formatted } = getDeadlineDisplay(funding);
+    const deadline = formatted || 'Date TBC';
+    const rawDeadline = formatDate(funding?.application?.deadline);
+    const nextDeadline = formatDate(funding?.application?.next_deadline);
+    const amount = formatCurrencyDisplay(getAmountValue(funding));
+    const coverage = funding?.funding_details?.covers || [];
+    const requirements = funding?.eligibility?.requirements || [];
+
+    let secondaryDeadlineBlock = '';
+    if (funding?.application?.deadline_source === 'next_deadline' && rawDeadline) {
+        secondaryDeadlineBlock = `<p><strong>Most recent deadline:</strong> ${rawDeadline}</p>`;
+    } else if (nextDeadline && nextDeadline !== deadline) {
+        secondaryDeadlineBlock = `<p><strong>Next cycle:</strong> ${nextDeadline}</p>`;
+    }
+
+    elements.modalContent.innerHTML = `
+        <h2 id="modalTitle">${funding.title}</h2>
+        <p><strong>Organisation:</strong> ${funding.organization || 'Unknown organisation'}</p>
+        <p><strong>Category:</strong> ${(funding.category || 'Other').toUpperCase()}</p>
+        <p><strong>Funding amount:</strong> ${amount}</p>
+        <p><strong>${deadlineLabel}:</strong> ${deadline}</p>
+        ${secondaryDeadlineBlock}
+        <p>${funding.description || ''}</p>
+        ${renderListBlock('Covers', coverage)}
+        ${renderListBlock('Eligibility requirements', requirements)}
+        ${funding?.application?.application_url ? `<a class="button" href="${funding.application.application_url}" target="_blank" rel="noopener">Apply on website</a>` : ''}
+    `;
+
+    elements.modal.hidden = false;
+    document.body.style.overflow = 'hidden';
+}
+
+function renderListBlock(title, items) {
+    if (!items || items.length === 0) {
+        return '';
+    }
+    const list = items
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    return `
+        <div>
+            <h3>${title}</h3>
+            <ul>${list}</ul>
         </div>
     `;
-    
-    modal.style.display = 'block';
 }
 
-// Close modal
-function closeModalHandler() {
-    modal.style.display = 'none';
+function closeModal() {
+    if (!elements.modal) return;
+    elements.modal.hidden = true;
+    document.body.style.overflow = '';
 }
 
-// Utility functions
-function debounce(func, wait) {
+function updateAISummary(summary) {
+    if (!summary || !elements.aiSummarySection) {
+        showAISummaryFallback('AI summary is not available yet.');
+        return;
+    }
+
+    elements.aiSummaryOverview.textContent = summary.overall_summary || 'Automated briefing ready.';
+    elements.aiSummaryTimestamp.textContent = summary.generated_at
+        ? `Generated ${new Date(summary.generated_at).toLocaleString()}`
+        : 'Generated recently';
+
+    if (summary.coverage_window?.label) {
+        elements.aiCoverageWindow.textContent = `Window: ${summary.coverage_window.label}`;
+    }
+
+    renderSimpleList(elements.aiHighlights, summary.highlights, (item) => `<li>${item}</li>`);
+    renderSimpleList(
+        elements.aiUpcoming,
+        summary.upcoming_deadlines,
+        (item) => `
+            <li>
+                <strong>${item.title}</strong>
+                <span>${item.organization} · ${item.deadline} (${item.days_remaining} days left)</span>
+            </li>
+        `
+    );
+    renderSimpleList(
+        elements.aiTopBodies,
+        summary.top_funding_bodies,
+        (item) => `
+            <li>
+                <strong>${item.organization}</strong>
+                <span>${item.opportunity_count} opportunities</span>
+            </li>
+        `
+    );
+    renderSimpleList(
+        elements.aiCareerFocus,
+        summary.career_stage_focus,
+        (item) => `
+            <li>
+                <strong>${item.stage}</strong>
+                <span>${item.opportunity_count} opportunities</span>
+            </li>
+        `
+    );
+    renderSimpleList(
+        elements.aiHighValue,
+        summary.high_value_awards,
+        (item) => `
+            <li>
+                <strong>${item.title}</strong>
+                <span>${item.organization} · ${item.amount} · Deadline: ${item.deadline}</span>
+            </li>
+        `
+    );
+
+    updateHeroHighlight(summary);
+    updateQualityNotes(summary.quality_notes || []);
+}
+
+function updateHeroHighlight(summary) {
+    if (!elements.heroHighlight) return;
+    const firstHighlight = summary.highlights?.[0];
+    const heroText = firstHighlight || summary.overall_summary || 'Daily briefing ready.';
+    elements.heroHighlight.innerHTML = `<p class="hero__snapshot-text">${heroText}</p>`;
+}
+
+function updateQualityNotes(notes) {
+    if (!elements.qualityNotes) return;
+    if (!notes.length) {
+        elements.qualityNotes.innerHTML = '';
+        return;
+    }
+    elements.qualityNotes.innerHTML = notes.map((note) => `<span>${note}</span>`).join('');
+}
+
+function showAISummaryFallback(message) {
+    elements.aiSummaryOverview.textContent = message;
+    elements.aiSummaryTimestamp.textContent = '—';
+    elements.aiCoverageWindow.textContent = 'Window: —';
+    ['aiHighlights', 'aiUpcoming', 'aiTopBodies', 'aiCareerFocus', 'aiHighValue'].forEach((key) => {
+        const container = elements[key];
+        if (container) {
+            container.innerHTML = '<li>No data available.</li>';
+        }
+    });
+    updateQualityNotes([]);
+}
+
+function renderSimpleList(container, items, templateFn) {
+    if (!container) return;
+    if (!items || !items.length) {
+        container.innerHTML = '<li>No data available.</li>';
+        return;
+    }
+    container.innerHTML = items.map(templateFn).join('');
+}
+
+function showErrorState(message) {
+    if (!elements.noResults) return;
+    elements.noResults.hidden = false;
+    elements.noResults.querySelector('h3').textContent = 'Unable to load data';
+    elements.noResults.querySelector('p').textContent = message;
+}
+
+function enrichFunding(funding, windowStart, windowEnd) {
+    const application = { ...(funding.application || {}) };
+    const { date, source } = resolveActiveDeadline(application, windowStart, windowEnd);
+
+    if (date) {
+        application.active_deadline = date.toISOString();
+        if (source) {
+            application.deadline_source = source;
+        } else {
+            delete application.deadline_source;
+        }
+    } else {
+        delete application.active_deadline;
+        delete application.deadline_source;
+    }
+
+    return { ...funding, application };
+}
+
+function resolveActiveDeadline(application, windowStart, windowEnd) {
+    const active = parseDeadline(application.active_deadline);
+    if (active) {
+        return { date: active, source: application.deadline_source || 'active_deadline' };
+    }
+
+    const deadline = parseDeadline(application.deadline);
+    const nextDeadline = parseDeadline(application.next_deadline);
+
+    const inWindow = (value) => value && value >= windowStart && value <= windowEnd;
+
+    if (inWindow(deadline)) {
+        return { date: deadline, source: 'deadline' };
+    }
+
+    if (inWindow(nextDeadline)) {
+        return { date: nextDeadline, source: 'next_deadline' };
+    }
+
+    const futureCandidates = [
+        { date: deadline, source: 'deadline' },
+        { date: nextDeadline, source: 'next_deadline' },
+    ];
+
+    for (const candidate of futureCandidates) {
+        if (candidate.date && candidate.date >= windowStart) {
+            return candidate;
+        }
+    }
+
+    if (deadline) {
+        return { date: deadline, source: 'deadline' };
+    }
+
+    if (nextDeadline) {
+        return { date: nextDeadline, source: 'next_deadline' };
+    }
+
+    return { date: null, source: null };
+}
+
+function parseDeadline(value) {
+    if (!value) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function getActiveDeadlineDate(funding) {
+    return (
+        parseDeadline(funding?.application?.active_deadline) ||
+        parseDeadline(funding?.application?.deadline) ||
+        parseDeadline(funding?.application?.next_deadline)
+    );
+}
+
+function formatDate(value) {
+    const date = parseDeadline(value);
+    if (!date) return null;
+    return new Intl.DateTimeFormat('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date);
+}
+
+function getAmountValue(funding) {
+    const amount = funding?.funding_details?.amount || {};
+    return amount.max || amount.min || 0;
+}
+
+function formatCurrencyDisplay(value) {
+    if (!value) return 'Unknown';
+    if (value >= 1_000_000_000) {
+        return `£${(value / 1_000_000_000).toFixed(2)}bn`;
+    }
+    if (value >= 1_000_000) {
+        return `£${(value / 1_000_000).toFixed(1)}m`;
+    }
+    if (value >= 1_000) {
+        return `£${Math.round(value / 1_000)}k`;
+    }
+    return `£${value.toLocaleString()}`;
+}
+
+function debounce(fn, wait = 150) {
     let timeout;
-    return function executedFunction(...args) {
-        const later = () => {
-            clearTimeout(timeout);
-            func(...args);
-        };
+    return (...args) => {
         clearTimeout(timeout);
-        timeout = setTimeout(later, wait);
+        timeout = setTimeout(() => fn.apply(null, args), wait);
     };
 }
 
-function formatNumber(num) {
-    // Convert from pence to pounds if the number is very large (likely in pence)
-    if (num > 1000000) {
-        num = num / 100;
-    }
-    return new Intl.NumberFormat('en-GB').format(num);
+function getDeadlineDisplay(funding) {
+    const application = funding?.application || {};
+    const label = application.deadline_source === 'next_deadline' ? 'Next deadline' : 'Deadline';
+    const value = application.active_deadline || application.deadline || application.next_deadline;
+    return {
+        label,
+        formatted: formatDate(value),
+    };
 }
 
-function formatDate(date) {
-    return date.toLocaleDateString('en-GB', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
+function resetFilters() {
+    elements.searchInput.value = '';
+    elements.careerStageFilter.value = '';
+    elements.sourceFilters.forEach((checkbox) => {
+        checkbox.checked = true;
     });
+    elements.sortSelect.value = 'deadline';
+    applyFilters();
 }
 
-function showError(message) {
-    fundingGrid.innerHTML = `
-        <div style="grid-column: 1 / -1; text-align: center; padding: 2rem; color: #e74c3c;">
-            <i class="fas fa-exclamation-triangle" style="font-size: 2rem; margin-bottom: 1rem;"></i>
-            <h3>Error</h3>
-            <p>${message}</p>
+function updateCategoryStats(fundings) {
+    const container = document.getElementById('categoryStats');
+    if (!container) return;
+    const counts = countBy(fundings, (funding) => funding.category || 'Other');
+    renderStatList(container, counts, fundings.length);
+}
+
+function updateCareerStats(fundings) {
+    const container = document.getElementById('careerStats');
+    if (!container) return;
+    const counts = countBy(fundings, (funding) => funding?.eligibility?.career_stage || 'All');
+    renderStatList(container, counts, fundings.length);
+}
+
+function updateFundingRange(fundings) {
+    const container = document.getElementById('fundingRange');
+    if (!container) return;
+    if (!fundings.length) {
+        container.innerHTML = '<p>No funding data available.</p>';
+        return;
+    }
+    const amounts = fundings.map(getAmountValue);
+    const max = Math.max(...amounts);
+    const min = Math.min(...amounts.filter((value) => value > 0));
+    container.innerHTML = `
+        <div class="stat-item">
+            <span class="stat-label">Largest award</span>
+            <span>${formatCurrencyDisplay(max)}</span>
+        </div>
+        <div class="stat-item">
+            <span class="stat-label">Smallest award</span>
+            <span>${min === Infinity ? 'Unknown' : formatCurrencyDisplay(min)}</span>
         </div>
     `;
+}
+
+function updateDeadlineStats(fundings) {
+    const container = document.getElementById('deadlineStats');
+    if (!container) return;
+    if (!fundings.length) {
+        container.innerHTML = '<p>No deadlines available.</p>';
+        return;
+    }
+    const buckets = {
+        '0-14 days': 0,
+        '15-30 days': 0,
+        '31-60 days': 0,
+        '61-90 days': 0,
+    };
+    const now = Date.now();
+    fundings.forEach((funding) => {
+        const deadline = getActiveDeadlineDate(funding);
+        if (!deadline) return;
+        const diff = deadline.getTime() - now;
+        const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+        const safeDays = Math.max(days, 0);
+        if (safeDays <= 14) buckets['0-14 days'] += 1;
+        else if (safeDays <= 30) buckets['15-30 days'] += 1;
+        else if (safeDays <= 60) buckets['31-60 days'] += 1;
+        else buckets['61-90 days'] += 1;
+    });
+    renderStatList(container, buckets, fundings.length);
+}
+
+function updateOrganizationStats(fundings) {
+    const container = document.getElementById('organizationStats');
+    if (!container) return;
+    const counts = countBy(fundings, (funding) => funding.organization || 'Unknown');
+    const entries = Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 6);
+    renderStatList(container, Object.fromEntries(entries), fundings.length);
+}
+
+function updateCompetitionStats(fundings) {
+    const container = document.getElementById('competitionStats');
+    if (!container) return;
+    const counts = countBy(fundings, (funding) => funding?.key_info?.competition_level || 'Not stated');
+    renderStatList(container, counts, fundings.length);
+}
+
+function countBy(items, keyFn) {
+    return items.reduce((acc, item) => {
+        const key = keyFn(item);
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+}
+
+function renderStatList(container, counts, total) {
+    if (!total) {
+        container.innerHTML = '<p>No data available.</p>';
+        return;
+    }
+    const markup = Object.entries(counts)
+        .sort((a, b) => b[1] - a[1])
+        .map(([label, count]) => {
+            const percentage = Math.round((count / total) * 100);
+            return `
+                <div class="stat-item">
+                    <div class="stat-label">${label}</div>
+                    <div class="stat-progress">
+                        <div class="stat-progress-fill" style="width: ${percentage}%"></div>
+                    </div>
+                    <div>${count} (${percentage}%)</div>
+                </div>
+            `;
+        })
+        .join('');
+    container.innerHTML = markup || '<p>No data available.</p>';
 }

--- a/scrapers/daily_scheduler.py
+++ b/scrapers/daily_scheduler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Utility script to schedule the daily scraping routine."""
+
+import argparse
+import time
+from datetime import datetime, timezone
+
+from loguru import logger
+
+from update_all import FundingDataUpdater
+
+
+def run_update() -> bool:
+    updater = FundingDataUpdater()
+    success = updater.update_all()
+    if success:
+        logger.info("Daily update finished successfully")
+    else:
+        logger.error("Daily update encountered errors")
+    return success
+
+
+def sleep_until_next_run(interval_hours: float) -> None:
+    seconds = max(interval_hours * 3600, 60)
+    logger.info(f"Sleeping for {interval_hours} hours before the next run...")
+    time.sleep(seconds)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run funding scrapers on a schedule")
+    parser.add_argument(
+        "--interval-hours",
+        type=float,
+        default=24.0,
+        help="Interval in hours between runs when --run-once is not provided (default: 24)",
+    )
+    parser.add_argument(
+        "--run-once",
+        action="store_true",
+        help="Execute the update a single time and exit",
+    )
+
+    args = parser.parse_args()
+
+    if args.run_once:
+        run_update()
+        return
+
+    logger.info("Starting continuous update loop")
+    while True:
+        start = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        logger.info(f"Starting scheduled update at {start}")
+        run_update()
+        sleep_until_next_run(args.interval_hours)
+
+if __name__ == "__main__":
+    main()

--- a/scrapers/data_quality.py
+++ b/scrapers/data_quality.py
@@ -1,0 +1,197 @@
+"""Data quality helpers for filtering and validating scraped funding calls."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Tuple
+
+REQUIRED_FIELDS: Tuple[str, ...] = (
+    "id",
+    "title",
+    "organization",
+    "category",
+    "description",
+)
+
+
+class FundingQualityReport(Dict[str, object]):
+    """Typed dictionary returned after sanitising funding calls."""
+
+
+def _to_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        try:
+            dt = datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _select_deadline(
+    funding: Dict,
+    window_start: datetime,
+    window_end: datetime,
+) -> Tuple[datetime | None, str | None]:
+    """Pick the most relevant deadline for a funding record."""
+
+    application = funding.get("application") or {}
+
+    # Honour any precomputed deadline first (for example from cached datasets).
+    active_deadline = _to_datetime(application.get("active_deadline"))
+    if active_deadline:
+        return active_deadline, application.get("deadline_source")
+
+    deadline = _to_datetime(application.get("deadline"))
+    next_deadline = _to_datetime(application.get("next_deadline"))
+
+    def _in_window(value: datetime | None) -> bool:
+        return bool(value and window_start <= value <= window_end)
+
+    if _in_window(deadline):
+        return deadline, "deadline"
+
+    if _in_window(next_deadline):
+        return next_deadline, "next_deadline"
+
+    # Prefer future dates even if slightly outside the strict window so that
+    # recurring calls with stale ``deadline`` but fresh ``next_deadline`` survive
+    # long enough to be revalidated on the next crawl.
+    future_candidates = [
+        (deadline, "deadline"),
+        (next_deadline, "next_deadline"),
+    ]
+    for candidate, source in future_candidates:
+        if candidate and candidate >= window_start:
+            return candidate, source
+
+    if deadline:
+        return deadline, "deadline"
+
+    if next_deadline:
+        return next_deadline, "next_deadline"
+
+    return None, None
+
+
+def sanitise_fundings(
+    fundings: Iterable[Dict],
+    *,
+    window_months: int = 3,
+    log=None,
+) -> Tuple[List[Dict], FundingQualityReport]:
+    """Validate scraped fundings and enforce a rolling time window.
+
+    Args:
+        fundings: Raw funding payloads from scrapers.
+        window_months: Symmetric window applied before/after now.
+        log: Optional logger with ``info``/``warning`` methods.
+
+    Returns:
+        A tuple containing the curated list of fundings and a quality report
+        describing dropped records.
+    """
+
+    now = datetime.now(timezone.utc)
+    window_delta = timedelta(days=window_months * 30)
+    window_start = now - window_delta
+    window_end = now + window_delta
+
+    curated: List[Dict] = []
+    seen_ids: set[str] = set()
+    total_seen = 0
+    dropped: Dict[str, int] = {
+        "missing_fields": 0,
+        "duplicate": 0,
+        "undated": 0,
+        "outside_window": 0,
+    }
+    substitutions: Dict[str, int] = {
+        "primary_deadline_used": 0,
+        "next_deadline_used": 0,
+    }
+
+    for funding in fundings:
+        total_seen += 1
+        missing = [field for field in REQUIRED_FIELDS if not funding.get(field)]
+        if missing:
+            dropped["missing_fields"] += 1
+            if log:
+                log.warning(
+                    "Discarded funding {id} due to missing required fields: {fields}".format(
+                        id=funding.get("id", "<unknown>"),
+                        fields=", ".join(missing),
+                    )
+                )
+            continue
+
+        identifier = str(funding["id"])
+        if identifier in seen_ids:
+            dropped["duplicate"] += 1
+            if log:
+                log.warning(f"Discarded duplicate funding id {identifier}")
+            continue
+        seen_ids.add(identifier)
+
+        selected_deadline, source = _select_deadline(funding, window_start, window_end)
+
+        if selected_deadline is None:
+            dropped["undated"] += 1
+            if log:
+                log.warning(
+                    f"Discarded funding {identifier} because the deadline is missing or invalid"
+                )
+            continue
+
+        if not (window_start <= selected_deadline <= window_end):
+            dropped["outside_window"] += 1
+            if log:
+                log.info(
+                    "Filtered out funding {id} with deadline {deadline} outside of window {start} – {end}".format(
+                        id=identifier,
+                        deadline=selected_deadline.isoformat(),
+                        start=window_start.isoformat(),
+                        end=window_end.isoformat(),
+                    )
+                )
+            continue
+
+        if source == "next_deadline":
+            substitutions["next_deadline_used"] += 1
+        else:
+            substitutions["primary_deadline_used"] += 1
+
+        application = funding.setdefault("application", {})
+        application["active_deadline"] = selected_deadline.isoformat()
+        if source:
+            application["deadline_source"] = source
+
+        curated.append(funding)
+
+    report: FundingQualityReport = FundingQualityReport(
+        total=total_seen,
+        retained=len(curated),
+        dropped=dropped,
+        window={
+            "start": window_start.isoformat(),
+            "end": window_end.isoformat(),
+            "months": window_months,
+        },
+        substitutions=substitutions,
+    )
+
+    if log:
+        log.info(
+            "Sanitised fundings: retained {retained} of {total} opportunities (window {start} to {end})".format(
+                retained=report["retained"],
+                total=report["total"],
+                start=window_start.date(),
+                end=window_end.date(),
+            )
+        )
+
+    return curated, report

--- a/scrapers/summarizer.py
+++ b/scrapers/summarizer.py
@@ -1,0 +1,242 @@
+"""Utility module for generating AI-style summaries of funding data."""
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional
+
+
+def _safe_get(dct: Dict, path: Iterable[str], default=""):
+    current = dct
+    for key in path:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+    return current
+
+
+def _format_currency(value: int) -> str:
+    if value is None or value <= 0:
+        return "Unknown"
+    if value >= 1_000_000_000:
+        return f"£{value/1_000_000_000:.2f}bn"
+    if value >= 1_000_000:
+        return f"£{value/1_000_000:.1f}m"
+    if value >= 1_000:
+        return f"£{value/1_000:.0f}k"
+    return f"£{value:,}"
+
+
+def _format_deadline(deadline: str) -> str:
+    try:
+        date_obj = datetime.fromisoformat(deadline)
+    except (TypeError, ValueError):
+        return "Date TBC"
+    return date_obj.strftime("%d %b %Y")
+
+
+def _extract_amount_range(funding: Dict) -> int:
+    amount = funding.get("funding_details", {}).get("amount", {})
+    return int(amount.get("max") or amount.get("min") or 0)
+
+
+def _resolve_window(window_days: int, quality_report: Optional[Dict]) -> Dict[str, str]:
+    now = datetime.now(timezone.utc)
+    default_start = now - timedelta(days=window_days)
+    default_end = now + timedelta(days=window_days)
+
+    if quality_report:
+        window = quality_report.get("window", {})
+        start = window.get("start")
+        end = window.get("end")
+        try:
+            if start and end:
+                start_dt = datetime.fromisoformat(start)
+                end_dt = datetime.fromisoformat(end)
+                if start_dt.tzinfo is None:
+                    start_dt = start_dt.replace(tzinfo=timezone.utc)
+                if end_dt.tzinfo is None:
+                    end_dt = end_dt.replace(tzinfo=timezone.utc)
+                return {
+                    "start": start_dt.isoformat(),
+                    "end": end_dt.isoformat(),
+                    "label": f"{start_dt.strftime('%d %b %Y')} – {end_dt.strftime('%d %b %Y')}",
+                }
+        except ValueError:
+            pass
+
+    return {
+        "start": default_start.isoformat(),
+        "end": default_end.isoformat(),
+        "label": f"{default_start.strftime('%d %b %Y')} – {default_end.strftime('%d %b %Y')}",
+    }
+
+
+def _quality_notes(quality_report: Optional[Dict]) -> List[str]:
+    if not quality_report:
+        return []
+
+    dropped = quality_report.get("dropped", {})
+    notes: List[str] = []
+    drop_messages = {
+        "missing_fields": "missing critical metadata",
+        "duplicate": "duplicate identifiers",
+        "undated": "undated deadlines",
+        "outside_window": "deadlines outside the 3-month window",
+    }
+
+    for key, reason in drop_messages.items():
+        count = dropped.get(key, 0)
+        if count:
+            notes.append(f"{count} entries skipped due to {reason}.")
+
+    retained = quality_report.get("retained")
+    total = quality_report.get("total")
+    if retained is not None and total:
+        notes.insert(0, f"Curated {retained} of {total} scraped opportunities after validation checks.")
+
+    return notes
+
+
+def generate_ai_summary(fundings: List[Dict], *, window_days: int = 90, quality_report: Optional[Dict] = None) -> Dict:
+    """Create a structured natural-language summary for researchers."""
+    generated_at = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+    total = len(fundings)
+    window_info = _resolve_window(window_days, quality_report)
+    notes = _quality_notes(quality_report)
+
+    if total == 0:
+        return {
+            "generated_at": generated_at,
+            "overall_summary": "No active funding opportunities were found in the latest crawl.",
+            "highlights": [
+                "The automated scrapers did not return any new opportunities today. Please check back later."
+            ],
+            "upcoming_deadlines": [],
+            "top_funding_bodies": [],
+            "career_stage_focus": [],
+            "coverage_window": window_info,
+            "quality_notes": notes,
+        }
+
+    category_counter = Counter(f.get("category", "Uncategorised") for f in fundings)
+    top_categories = category_counter.most_common(3)
+
+    organisations = Counter(f.get("organization", "Unknown organisation") for f in fundings)
+    top_orgs = organisations.most_common(5)
+
+    career_stage_counter = Counter(
+        _safe_get(f, ("eligibility", "career_stage"), "All career stages") for f in fundings
+    )
+    top_career = career_stage_counter.most_common(3)
+
+    # Upcoming deadlines within 14 days
+    upcoming: List[Dict] = []
+    now = datetime.now(timezone.utc)
+    for funding in fundings:
+        deadline = _safe_get(funding, ("application", "deadline"))
+        try:
+            if not deadline:
+                continue
+            deadline_dt = datetime.fromisoformat(deadline)
+            if deadline_dt.tzinfo is None:
+                deadline_dt = deadline_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        delta = (deadline_dt - now).days
+        if 0 <= delta <= 14:
+            upcoming.append({
+                "title": funding.get("title", "Untitled opportunity"),
+                "organization": funding.get("organization", ""),
+                "deadline": deadline,
+                "days_remaining": delta,
+            })
+    upcoming.sort(key=lambda item: item["days_remaining"])
+    upcoming = upcoming[:5]
+
+    # High value opportunities
+    high_value_candidates = sorted(
+        [
+            {
+                "title": funding.get("title", "Untitled opportunity"),
+                "organization": funding.get("organization", ""),
+                "amount": _extract_amount_range(funding),
+                "deadline": _safe_get(funding, ("application", "deadline")),
+            }
+            for funding in fundings
+        ],
+        key=lambda item: item["amount"],
+        reverse=True,
+    )
+
+    high_value = []
+    seen_titles = set()
+    for item in high_value_candidates:
+        key = (item["title"], item["organization"], item["amount"])
+        if key in seen_titles:
+            continue
+        seen_titles.add(key)
+        high_value.append(item)
+        if len(high_value) == 5:
+            break
+
+    highlights = [
+        f"Curated {total} funding opportunities with deadlines between {window_info['label']}."
+    ]
+    if top_categories:
+        highlights.append(
+            "Top thematic areas today: "
+            + ", ".join(f"{name.upper()} ({count})" for name, count in top_categories)
+            + "."
+        )
+    if upcoming:
+        highlights.append(
+            f"{len(upcoming)} opportunities are closing within the next two weeks; prioritise applications soon."
+        )
+    if high_value:
+        highlights.append(
+            f"Highest available award tops out at {_format_currency(high_value[0]['amount'])}."
+        )
+
+    overall_summary = (
+        "Daily crawl completed: "
+        f"{total} validated opportunities remain after quality checks, "
+        "all with deadlines inside the rolling three-month window. "
+        "Insights highlight where researchers should focus immediate attention and the most lucrative calls open right now."
+    )
+
+    return {
+        "generated_at": generated_at,
+        "overall_summary": overall_summary,
+        "highlights": highlights,
+        "upcoming_deadlines": [
+            {
+                "title": item["title"],
+                "organization": item["organization"],
+                "deadline": _format_deadline(item["deadline"]),
+                "days_remaining": item["days_remaining"],
+            }
+            for item in upcoming
+        ],
+        "top_funding_bodies": [
+            {"organization": name, "opportunity_count": count}
+            for name, count in top_orgs
+        ],
+        "career_stage_focus": [
+            {"stage": name, "opportunity_count": count}
+            for name, count in top_career
+        ],
+        "high_value_awards": [
+            {
+                "title": item["title"],
+                "organization": item["organization"],
+                "amount": _format_currency(item["amount"]),
+                "deadline": _format_deadline(item["deadline"]),
+            }
+            for item in high_value
+            if item["amount"] > 0
+        ],
+        "coverage_window": window_info,
+        "quality_notes": notes,
+    }

--- a/scrapers/update_all.py
+++ b/scrapers/update_all.py
@@ -14,7 +14,7 @@ import argparse
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 from loguru import logger
 
@@ -23,6 +23,8 @@ from ukri_scraper import UKRIScraper
 from academies_scraper import AcademiesScraper
 from foundations_scraper import FoundationsScraper
 from utils import setup_directories, update_database, save_json, load_json
+from summarizer import generate_ai_summary
+from data_quality import sanitise_fundings
 
 class FundingDataUpdater:
     """Main class to coordinate funding data updates."""
@@ -44,6 +46,7 @@ class FundingDataUpdater:
         logger.info("Starting complete funding data update...")
         
         all_fundings = []
+        source_lookup = {}
         success_count = 0
         
         for scraper_name, scraper in self.scrapers.items():
@@ -60,8 +63,11 @@ class FundingDataUpdater:
                     continue
                 
                 if fundings:
-                    all_fundings.extend(fundings)
-                    self.save_individual_fundings(fundings, scraper_name)
+                    for item in fundings:
+                        all_fundings.append(item)
+                        identifier = str(item.get('id'))
+                        if identifier:
+                            source_lookup[identifier] = scraper_name
                     success_count += 1
                     logger.info(f"Successfully scraped {len(fundings)} opportunities from {scraper_name}")
                 else:
@@ -72,10 +78,21 @@ class FundingDataUpdater:
         
         # Update main database
         if all_fundings:
+            curated_fundings, quality_report = sanitise_fundings(all_fundings, log=logger)
+            if not curated_fundings:
+                logger.warning("All scraped opportunities were filtered out by quality checks")
+                return False
             database_path = self.dirs['data'] / 'funding_database.json'
-            if update_database(all_fundings, database_path):
-                logger.info(f"Successfully updated database with {len(all_fundings)} total opportunities")
-                self.generate_summary_report(all_fundings)
+            if update_database(curated_fundings, database_path):
+                logger.info(
+                    "Successfully updated database with {curated} curated opportunities (from {scraped} scraped)".format(
+                        curated=len(curated_fundings),
+                        scraped=len(all_fundings),
+                    )
+                )
+                self.save_individual_fundings(curated_fundings, source_lookup)
+                self.generate_summary_report(curated_fundings)
+                self.generate_ai_brief(curated_fundings, quality_report)
                 return True
             else:
                 logger.error("Failed to update main database")
@@ -89,6 +106,7 @@ class FundingDataUpdater:
         logger.info(f"Running specific scrapers: {', '.join(scraper_names)}")
         
         all_fundings = []
+        source_lookup = {}
         
         for scraper_name in scraper_names:
             if scraper_name not in self.scrapers:
@@ -109,8 +127,11 @@ class FundingDataUpdater:
                     continue
                 
                 if fundings:
-                    all_fundings.extend(fundings)
-                    self.save_individual_fundings(fundings, scraper_name)
+                    for item in fundings:
+                        all_fundings.append(item)
+                        identifier = str(item.get('id'))
+                        if identifier:
+                            source_lookup[identifier] = scraper_name
                     logger.info(f"Successfully scraped {len(fundings)} opportunities from {scraper_name}")
                 
             except Exception as e:
@@ -118,15 +139,24 @@ class FundingDataUpdater:
         
         # Update database
         if all_fundings:
+            curated_fundings, quality_report = sanitise_fundings(all_fundings, log=logger)
+            if not curated_fundings:
+                logger.warning("All scraped opportunities were filtered out by quality checks")
+                return False
             database_path = self.dirs['data'] / 'funding_database.json'
-            return update_database(all_fundings, database_path)
+            if update_database(curated_fundings, database_path):
+                self.save_individual_fundings(curated_fundings, source_lookup)
+                self.generate_ai_brief(curated_fundings, quality_report)
+                return True
+            return False
         
         return False
     
-    def save_individual_fundings(self, fundings: List[Dict], scraper_name: str) -> None:
+    def save_individual_fundings(self, fundings: List[Dict], source_lookup: Dict[str, str]) -> None:
         """Save individual funding files."""
         for funding in fundings:
-            filename = f"{scraper_name}_{funding['subcategory']}_{funding['id']}.json"
+            source = source_lookup.get(str(funding['id']), 'aggregated')
+            filename = f"{source}_{funding['subcategory']}_{funding['id']}.json"
             file_path = self.dirs['individual_fundings'] / filename
             save_json(funding, file_path)
     
@@ -186,6 +216,20 @@ class FundingDataUpdater:
         logger.info(f"  By career stage: {career_stage_counts}")
         logger.info(f"  Upcoming deadlines (30 days): {upcoming_deadlines}")
         logger.info(f"  Total funding range: £{total_min_funding:,} - £{total_max_funding:,}")
+
+    def generate_ai_brief(self, fundings: List[Dict], quality_report: Optional[Dict] = None) -> None:
+        """Generate an AI-style natural language brief for the front-end."""
+        logger.info("Creating daily AI summary...")
+
+        try:
+            summary_payload = generate_ai_summary(fundings, quality_report=quality_report)
+        except Exception as exc:
+            logger.error(f"Failed to create AI summary: {exc}")
+            return
+
+        summary_path = self.dirs['data'] / 'ai_summary.json'
+        save_json(summary_payload, summary_path)
+        logger.info(f"AI summary saved to {summary_path}")
     
     def clean_old_data(self, days_old: int = 30) -> None:
         """Clean old individual funding files."""

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta, timezone
+
+from scrapers.data_quality import sanitise_fundings
+
+
+def _funding(template_id: str, deadline_offset: int, **overrides):
+    now = datetime.now(timezone.utc)
+    base = {
+        "id": template_id,
+        "title": f"Opportunity {template_id}",
+        "organization": "Org",
+        "category": "ukri",
+        "subcategory": "sample",
+        "description": "Description",
+        "eligibility": {"career_stage": "Early Career"},
+        "funding_details": {"amount": {"min": 1000, "max": 2000}},
+        "application": {"deadline": (now + timedelta(days=deadline_offset)).date().isoformat()},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_sanitise_filters_outside_window_and_duplicates():
+    fundings = [
+        _funding("valid", 10),
+        _funding("duplicate", 15),
+        _funding("duplicate", 15),
+        _funding("old", -200),
+        _funding("missing", 20, description=""),
+        _funding("nodate", 0, application={}),
+    ]
+
+    curated, report = sanitise_fundings(fundings, window_months=3)
+
+    assert len(curated) == 2
+    ids = {item["id"] for item in curated}
+    assert ids == {"valid", "duplicate"}
+    assert report["dropped"]["duplicate"] == 1
+    assert report["dropped"]["outside_window"] == 1
+    assert report["dropped"]["missing_fields"] == 1
+    assert report["dropped"]["undated"] == 1
+    assert report["substitutions"]["primary_deadline_used"] == 2
+
+
+def test_sanitise_uses_next_deadline_when_primary_is_stale():
+    now = datetime.now(timezone.utc)
+    stale = _funding("stale", -200)
+    stale["application"]["next_deadline"] = (now + timedelta(days=45)).date().isoformat()
+
+    curated, report = sanitise_fundings([stale], window_months=3)
+
+    assert len(curated) == 1
+    active_deadline = curated[0]["application"]["active_deadline"]
+    assert active_deadline is not None
+    assert report["substitutions"]["next_deadline_used"] == 1

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta, timezone
+
+from scrapers.data_quality import sanitise_fundings
+from scrapers.summarizer import generate_ai_summary
+
+
+def _sample_fundings():
+    now = datetime.now(timezone.utc)
+    base_deadline = (now + timedelta(days=21)).date().isoformat()
+    return [
+        {
+            "id": "sample-1",
+            "title": "Sample Opportunity",
+            "organization": "Sample Council",
+            "category": "ukri",
+            "subcategory": "sample",
+            "description": "Support for innovative sample projects.",
+            "eligibility": {"career_stage": "Early Career", "requirements": []},
+            "funding_details": {"amount": {"min": 100000, "max": 250000, "currency": "GBP"}},
+            "application": {"deadline": base_deadline, "application_url": "https://example.com"},
+            "key_info": {"competition_level": "Competitive"},
+        },
+        {
+            "id": "sample-2",
+            "title": "Flagship Fellowship",
+            "organization": "National Academy",
+            "category": "academies",
+            "subcategory": "academy",
+            "description": "Fellowship funding for interdisciplinary work.",
+            "eligibility": {"career_stage": "Mid Career", "requirements": []},
+            "funding_details": {"amount": {"min": 50000, "max": 150000, "currency": "GBP"}},
+            "application": {"deadline": (now + timedelta(days=50)).date().isoformat()},
+            "key_info": {"competition_level": "Moderate"},
+        },
+    ]
+
+
+def test_generate_ai_summary_structure():
+    fundings = _sample_fundings()
+    curated, report = sanitise_fundings(fundings, window_months=3)
+
+    summary = generate_ai_summary(curated, quality_report=report)
+
+    assert summary["overall_summary"].startswith("Daily crawl completed")
+    assert isinstance(summary["highlights"], list) and summary["highlights"]
+    assert isinstance(summary["quality_notes"], list)
+    assert "coverage_window" in summary and "label" in summary["coverage_window"]
+    assert summary["top_funding_bodies"][0]["organization"] == "Sample Council"
+
+
+def test_generate_ai_summary_empty():
+    summary = generate_ai_summary([])
+    assert summary["highlights"][0].startswith("The automated scrapers")
+    assert summary["upcoming_deadlines"] == []
+    assert summary["quality_notes"] == []


### PR DESCRIPTION
## Summary
- use the data quality pass to resolve an active deadline (preferring next_deadline when the primary date is stale) and capture substitution stats in the report
- update the funding explorer front end to derive and display the active deadline window, including contextual labelling in cards and modal details
- extend the data quality test suite to exercise the new next_deadline path and confirm the substitution metrics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9ee3a418832eb292551459542609